### PR TITLE
Update services.rb

### DIFF
--- a/lib/tasks/helpers/services.rb
+++ b/lib/tasks/helpers/services.rb
@@ -70,8 +70,9 @@ module Services
     _log "Creating services on each of: #{hosts.map{|h| h.name } }"
 
     sister_entity = nil
+    thread_list = []
     hosts.uniq.each do |h|
-      Thread.new do 
+      thread_list << Thread.new do 
 
         # Handle web app case first
         if (protocol == "tcp" && [80,81,443,8000,8080,8081,8443].include?(port_num))
@@ -217,6 +218,7 @@ module Services
         end
       end # end thread 
     end # each hostname
+    thread_list.map(&:join)
   end
 
   ## Default method, subclasses must override this


### PR DESCRIPTION
During chasing a timeout issue, I was led to services.rb _create_network_service_entity

```
#<Thread:0x00007f2a8d3be9d0@/core/lib/tasks/helpers/services.rb:74 run> terminated with exception (report_on_exception is true):
/root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/connection_pool/threaded.rb:264:in `raise_pool_timeout': timeout: 240.0, elapsed: 242.178513612831 (Sequel::PoolTimeout)
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/connection_pool/threaded.rb:155:in `acquire'
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/connection_pool/threaded.rb:91:in `hold'
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/database/connecting.rb:270:in `synchronize'
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/adapters/postgres.rb:314:in `execute'
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/dataset/actions.rb:1087:in `execute'
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/adapters/postgres.rb:610:in `fetch_rows'
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/model/base.rb:939:in `primary_key_lookup'
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/model/associations.rb:2335:in `_load_associated_object_via_primary_key'
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/model/associations.rb:2355:in `_load_associated_objects'
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/model/associations.rb:2473:in `load_associated_objects'
        from /root/.rbenv/versions/2.5.1/gemsets/core/gems/sequel-5.17.0/lib/sequel/model/associations.rb:1924:in `block in def_association_method'
        from /core/lib/tasks/helpers/services.rb:89:in `block (2 levels) in _create_network_service_entity'
```

I noticed the threads are spawned with no explicit joining to ensure that they finish execution.  Stylistically, I just borrowed from your other methods (so there isn't a dozen ways used to join threads).  This didn't solve the timeout issue, so I'll keep hunting.