### PR TITLE
Typo Fix

### DIFF
--- a/lib/tasks/helpers/web.rb
+++ b/lib/tasks/helpers/web.rb
@@ -192,7 +192,7 @@ module Task
     rescue Errno::ECONNREFUSED => e
       _log_error "Error requesting cert - refused, skipping: #{hostname} #{port}: #{e}"
       _log_error "Error requesting resource, skipping: #{hostname} #{port}"
-      log "retrying... attempt: #{attempts}/#{max_attempts}"
+      _log "retrying... attempt: #{attempts}/#{max_attempts}"
       retry unless attempts == max_attempts
     rescue Errno::ETIMEDOUT => e
       _log_error "Error requesting cert - timed out, timeout: #{hostname} #{port}: #{e}"


### PR DESCRIPTION
Noticed a bug in the sidekiq log

```
2019-06-10T18:47:47.252Z 1022 TID-gpg9qt6oq WARN: NoMethodError: undefined method `log' for #<Intrigue::Task::UriGatherSslCert:0x00007fd36c023e78>
Did you mean?  _log
```

Looks like a quick typo.