### PR TITLE
Build fixes for Dockerfiles and bootstrap-worker.sh

### DIFF
--- a/Dockerfile-standalone
+++ b/Dockerfile-standalone
@@ -104,7 +104,7 @@ COPY . /core/
 RUN /bin/bash /core/util/bootstrap-standalone.sh
 
 # Remove the config file so one generates on startup (useful when testing)
-RUN rm /core/config/config.json
+RUN if [ -e /core/config/config.json ]; then rm /core/config/config.json; fi
 
 # Expose the port
 EXPOSE 7777

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -101,7 +101,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY . /core/
 
 # Remove the config files so we don't accidentally image ours!
-RUN rm /core/config/config.json
+RUN if [ -e /core/config/config.json ]; then rm /core/config/config.json; fi
 
 # Go get intrigue-specific software & config
 RUN /bin/bash /core/util/bootstrap-worker.sh

--- a/util/bootstrap-worker.sh
+++ b/util/bootstrap-worker.sh
@@ -38,7 +38,7 @@ sudo apt-get -y install lsb-core software-properties-common dirmngr apt-transpor
 # chrome repo
 echo "[+] Installing Chromium"
 #sudo apt-get install software-properties-common
-sudo add-apt-repository ppa:canonical-chromium-builds/stage
+sudo add-apt-repository -y ppa:canonical-chromium-builds/stage
 sudo apt-get update
 sudo apt-get -y install chromium-browser
 ##### Install dependencies after update


### PR DESCRIPTION
A couple small build fixes.  

We currently build Intrigue on a RedHat server using podman (rather than docker), and these are just changes to get it through the build process.  I don't believe that the build issues are podman specific, but I haven't tested against a docker build.  

The first 2 commits are just changes to the Dockerfiles
* Dockerfile-standalone
* Dockerfile-worker

The encountered error is:
```
rm: cannot remove '/core/config/config.json': No such file or directory
Error: error building at STEP "RUN rm /core/config/config.json": error while running runtime: exit status 1
125
```
This can be fixed by changing 
```
RUN rm /core/config/config.json
```
To a simple bash conditional
```
RUN if [ -e /core/config/config.json ]; then rm /core/config/config.json; fi
```

The second error encountered is from a warning put in by the PPA used for chromium.  The build will pause waiting for an ENTER or Ctrl-c.
```
[+] Installing Chromium
 Testing site just before upload to Ubuntu main. Things here are either broken and not ready to use, or landing in the distro anyway very soon. You shouldn't use this.
 More info: https://launchpad.net/~canonical-chromium-builds/+archive/ubuntu/stage
Press [ENTER] to continue or Ctrl-c to cancel adding it.
```
This can be fixed by proving a `-y` argument to `add-apt-repository`
```
sudo add-apt-repository -y ppa:canonical-chromium-builds/stage
```

After these changes I was able to successfully build the develop branch on RedHat using podman.