### PR TITLE
intrigue Core using Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,10 +1,22 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
 
   config.vm.define "intrigue-core" do |x|
 
-    x.vm.provision :shell, privileged: false, path: "util/bootstrap.sh"
-    x.vm.synced_folder ".", "/core"
+    x.vm.provision :shell, privileged: false, path: "util/bootstrap-standalone.sh"
+	x.vm.provision "shell", privileged: false, inline: <<-SHELL
+		cd /home/ubuntu/core
+		sudo -u postgres createuser vagrant -s
+		sudo -u postgres createdb vagrant
+		bundle exec rake db:migrate
+	SHELL
+	x.vm.provision "shell", privileged: false, run: "always", inline: <<-SHELL
+		cd /home/ubuntu/core
+		rake setup
+		god -c /home/ubuntu/core/util/god/intrigue-ec2.rb
+		god start
+	SHELL
+    x.vm.synced_folder ".", "/home/ubuntu/core"
     x.vm.hostname = "intrigue-core"
     x.vm.network :private_network, ip: "10.0.0.10"
     x.vm.network "forwarded_port", guest: 7777, host: 7777

--- a/util/bootstrap-standalone.sh
+++ b/util/bootstrap-standalone.sh
@@ -196,7 +196,9 @@ fi
 ### Install latest tika
 echo "[+] Installing Apache Tika"
 cd $INTRIGUE_DIRECTORY/tmp
-wget http://mirror.cogentco.com/pub/apache/tika/tika-server-1.24.jar
+LATEST_TIKA_VERSION=1.24
+wget http://apache.mirrors.ovh.net/ftp.apache.org/dist/tika/tika-server-$LATEST_TIKA_VERSION.jar
+mv $INTRIGUE_DIRECTORY/tmp/tika-server-$LATEST_TIKA_VERSION.jar $INTRIGUE_DIRECTORY/tmp/tika-server.jar
 cd $HOME
 
 # update sudoers

--- a/util/bootstrap-worker.sh
+++ b/util/bootstrap-worker.sh
@@ -190,7 +190,8 @@ fi
 echo "[+] Installing Apache Tika"
 cd $INTRIGUE_DIRECTORY/tmp
 LATEST_TIKA_VERSION=1.24
-wget http://apache.mirrors.hoobly.com/tika/$LATEST_TIKA_VERSION.jar
+wget http://apache.mirrors.ovh.net/ftp.apache.org/dist/tika/tika-server-$LATEST_TIKA_VERSION.jar
+mv $INTRIGUE_DIRECTORY/tmp/tika-server-$LATEST_TIKA_VERSION.jar $INTRIGUE_DIRECTORY/tmp/tika-server.jar
 cd $HOME
 
 # update sudoers

--- a/util/god/intrigue-docker.rb
+++ b/util/god/intrigue-docker.rb
@@ -43,6 +43,6 @@ God.watch do |w|
   w.name = "intrigue-tika"
   w.dir = "#{BASEDIR}" 
   w.log = "#{BASEDIR}/log/tika.log"
-  w.start = "java -jar #{BASEDIR}/tmp/tika-server-1.24.jar"
+  w.start = "java -jar #{BASEDIR}/tmp/tika-server.jar"
   w.keepalive
 end

--- a/util/god/intrigue-ec2.rb
+++ b/util/god/intrigue-ec2.rb
@@ -1,5 +1,5 @@
 God.pid_file_directory = "/home/ubuntu/core/tmp/pids"
-BASEDIR = "/home/ubuntu/core/"
+BASEDIR = "/home/ubuntu/core"
 
 God.watch do |w|
   w.group = "intrigue"
@@ -43,6 +43,6 @@ God.watch do |w|
   w.name = "intrigue-tika"
   w.dir = "#{BASEDIR}" 
   w.log = "#{BASEDIR}/log/tika.log"
-  w.start = "java -jar #{BASEDIR}/tmp/tika-server-1.24.jar"
+  w.start = "java -jar #{BASEDIR}/tmp/tika-server.jar"
   w.keepalive
 end


### PR DESCRIPTION
I followed the instructions for "Getting started with Intrigue Core on Vagrant" but had to make some changes to made it work:

**Vagrantfile:**
- the vagrant box "ubuntu/xenial64" is outdated, especially the redis-server in v3.x doesn't work with the current vagrant-core -> "ubuntu/bionic64" includes v4.x and works well.
- x.vm.provision: "util/bootstrap.sh" doesn't exists, I changed it to "util/bootstrap-standalone.sh"
- in "util/bootstrap-standalone.sh" the INTRIGUE_DIRECTORY is set to "/home/ubuntu/core", so I changed the x.vm.synced_folder accordingly
- I added 2 'x.vm.provision "shell"'-blocks: the first one only executes when provisioning, the second one executes every time the vagrant machine starts.
With this changes provisioning and starting the vagrant machine is simple: you only need "vagrant up --provider virtualbox", there is no need for "vagrant ssh" and additional commands anymore.

**util/bootstrap-standalone.sh, 
util/bootstrap-worker.sh, 
util/god/intrigue-docker.rb, 
util/god/intrigue-ec2.rb:**
The Apache Tika-server version is hardcoded in 4 files, which is error-prone. As a solution I rename the "tika-server-1.xx.jar" to "tika-server.jar" after downloading and added a "LATEST_TIKA_VERSION"-variable in bootstrap-standalone.sh. 
With this, both rb-files don't need to be edited every time the version changes.
Sorry for the different download links...

**util/god/intrigue-ec2.rb:**
There was a nasty trailing "/" in BASEDIR

**util/god/intrigue-docker.rb:**
BASEDIR="/core"
Is this correct? In all the other configuation files it is "/home/ubuntu/core"