### PR TITLE
Improvement to Netblock scoping

### DIFF
--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -21,7 +21,8 @@ module Intrigue
       one_to_many  :issues
 
       include Intrigue::Task::Helper
-
+      include Intrigue::System::Validations
+      
       def self.inherited(base)
         EntityFactory.register(base)
         super

--- a/core.rb
+++ b/core.rb
@@ -38,9 +38,12 @@ Intrigue::System::Config.load_config
 require_relative 'lib/system/database'
 include Intrigue::System::Database
 
+# used in app as well as tasks
+require_relative 'lib/system/validations'
+
 # Debug
-require 'pry'
-require 'pry-byebug'
+#require 'pry'
+#require 'pry-byebug'
 require 'logger'
 
 #

--- a/lib/entities/net_block.rb
+++ b/lib/entities/net_block.rb
@@ -12,7 +12,7 @@ class NetBlock < Intrigue::Model::Entity
   end
 
   def validate_entity
-    name =~ /^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}\/\d{1,2}$/ || name =~ /^[a-z\d\:]+\/\d{1,2}$/
+    name =~ netblock_regex || name =~ /^[a-z\d\:]+\/\d{1,2}$/
   end
 
   def detail_string
@@ -31,21 +31,20 @@ class NetBlock < Intrigue::Model::Entity
     return false if self.hidden # hit our blacklist so definitely false
 
     our_ip = self.name.split("/").first
-    our_route = self.name.split("/").last
+    our_route = self.name.split("/").last.to_i
     whois_text = "#{details["whois_full_text"]}"
 
-    # it's just one ip
-    if our_ip =~ /:/ && our_route == "64"
-      return true # ipv6
-    elsif our_route == "32"
-      return true # ipv4
+    # Check for case where we're just one ip address
+    if our_ip =~ ipv6_regex && our_route == 64
+      return true # ipv6 single ip
+    elsif our_ip =~ ipv4_regex && our_route == 32
+      return true # ipv4 single ip
     end
 
     ###
     ### First, Check our text to see if there's a more specific route in here, 
     ###  and if so, not ours.
     ####################################################################################
-    netblock_regex = /(\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}\/(\d{1,2}))/
     match_captures = whois_text.scan(netblock_regex)
     match_captures.each do |capture|
       

--- a/lib/issues/wordpress_config_leak.rb
+++ b/lib/issues/wordpress_config_leak.rb
@@ -5,7 +5,7 @@ module Intrigue
     def self.generate(instance_details={})
       {
         name: "wordpress_config_leak",
-        pretty_name: "Wordpress Configuraton Info Leak",
+        pretty_name: "Wordpress Configuration Information Leak",
         severity: 1,
         category: "application",
         status: "confirmed",

--- a/lib/system/validations.rb
+++ b/lib/system/validations.rb
@@ -3,6 +3,10 @@ module Intrigue
 module System
 module Validations
 
+  def netblock_regex
+    /^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}\/\d{1,2}$/
+  end
+
   ### Standard Validations, for use throughout the platform
   # https://tools.ietf.org/html/rfc1123
   def ipv4_regex

--- a/lib/tasks/helpers/data.rb
+++ b/lib/tasks/helpers/data.rb
@@ -26,7 +26,6 @@ module Data
     service_name || "UNKNOWN"
   end
 
-
   def _allocated_ipv4_ranges(filter="ALLOCATED")
     ranges = []
     file = File.open("#{$intrigue_basedir}/data/iana/ipv4-address-space.csv","r")


### PR DESCRIPTION
Improves netblock scoping to check for the case of IPv4 vs IPv6 single ip addresses. These should always be scoped in. Uses system system validations by loading it into the entity model, which will help with scattered regexes lying around in the codebase.  

Also, remove pry load by default, it can always be loaded in at time of debugging.