### PR TITLE
only create issues on applications with a hostname

### DIFF
--- a/lib/issues/insecure_cookie_httponly_attribute.rb
+++ b/lib/issues/insecure_cookie_httponly_attribute.rb
@@ -14,7 +14,7 @@ module Intrigue
         affected_software: [ ],
         references: [ # types: description, remediation, detection_rule, exploit, threat_intel
           { type: "description", uri: "https://owasp.org/www-community/HttpOnly" },
-          { type: "remediations", uri: "https://owasp.org/www-community/HttpOnly" }
+          { type: "remediation", uri: "https://owasp.org/www-community/HttpOnly" }
         ]
       }.merge!(instance_details)
     end

--- a/lib/issues/insecure_cookie_secure_attribute.rb
+++ b/lib/issues/insecure_cookie_secure_attribute.rb
@@ -14,7 +14,7 @@ module Intrigue
         affected_software: [ ],
         references: [ # types: description, remediation, detection_rule, exploit, threat_intel
           { type: "description", uri: "https://owasp.org/www-community/controls/SecureFlag" },
-          { type: "remediations", uri: "https://owasp.org/www-community/controls/SecureFlag" }
+          { type: "remediation", uri: "https://owasp.org/www-community/controls/SecureFlag" }
         ]
       }.merge!(instance_details)
     end

--- a/lib/machines/threat_investigation.rb
+++ b/lib/machines/threat_investigation.rb
@@ -4,12 +4,12 @@ class RunInvestigationTask < Intrigue::Machine::Base
 
     def self.metadata
       {
-        :name => "run_investigation_task",
-        :pretty_name => "Investigation Machine",
-        :passive => false,
+        :name => "threat_investigation",
+        :pretty_name => "Threat Investigation",
+        :passive => true,
         :user_selectable => true,
         :authors => ["Anas Ben Salah"],
-        :description => "This machine is for investigation purpose."
+        :description => "This machine is for gathering data on an IoC or suspected IoC. It gathers data from many different threat sources."
       }
     end
 

--- a/lib/tasks/helpers/issue.rb
+++ b/lib/tasks/helpers/issue.rb
@@ -75,16 +75,29 @@ module Issue
   ### Application oriented issues
   ###
 
+  ###
+  ### Generic finding coming from ident. 
+  ###
   def _create_content_issue(uri, check)
     _create_linked_issue("content_issue", { uri: uri, check: check })
   end
 
   def _create_missing_cookie_attribute_http_only_issue(uri, cookie, severity=5)
+    
+    # skip this for anything other than hostnames 
+    hostname = URI(uri).hostname
+    return if hostname =~ ipv4_regex || hostname =~ /ipv6_regex/
+    
     addtl_details = { cookie: cookie }
     _create_linked_issue("insecure_cookie_httponly_attribute", addtl_details)
   end
 
   def _create_missing_cookie_attribute_secure_issue(uri, cookie, severity=5)
+    
+    # skip this for anything other than hostnames 
+    hostname = URI(uri).hostname
+    return if hostname =~ ipv4_regex || hostname =~ /ipv6_regex/
+    
     addtl_details = { cookie: cookie }
     _create_linked_issue("insecure_cookie_secure_attribute", addtl_details)
   end
@@ -129,6 +142,10 @@ module Issue
     requests.each do |req|
 
       resource_url = req["url"]
+
+      # skip this for anything other than hostnames 
+      hostname = URI(resource_url).hostname
+      return if hostname =~ ipv4_regex || hostname =~ /ipv6_regex/
 
       if resource_url =~ /^http:.*$/ 
         _create_linked_issue("insecure_content_loaded", {


### PR DESCRIPTION
This work ensures we don't end up with a mass of secure-cookie issues on uri/app endpoints that don't have a hostname.

While technically valid, most users don't access an application by the ip address, and there are often strange unpredictable redirect chains on these. 

At this point, it's just noise, so this limits issue creation to those uri's with a hotstname.  