### PR TITLE
Fix a few bugs in the HIBP task and move (back) to sonar.intrigue.io

### DIFF
--- a/app/views/analysis/systems.erb
+++ b/app/views/analysis/systems.erb
@@ -40,22 +40,24 @@
     <p></p>
     <table class="sortable" border="1" width=100%>
       <colgroup>
-        <col style="width:20%">
-        <col style="width:20%">
-        <col style="width:20%">
-        <col style="width:20%">
-        <col style="width:20%">
+        <col style="width:15%">
+        <col style="width:15%">
+        <col style="width:15%">
+        <col style="width:15%">
+        <col style="width:15%">
+        <col style="width:15%">
       </colgroup>
       <tbody>
-      <tr><th>Ip Address</th><th>Aliases</th><th>OS</th><th>Ports</th><th>Provider</th></tr>
+      <tr><th>Ip Address</th><th>Aliases</th><th>OS</th><th>Ports</th><th>Network</th><th>Country</th></tr>
       <% @entities.each do |x| %>
         <tr>
           <% next unless x.type_string == "IpAddress" %>
           <td><a href="<%="/#{h @project_name}/entities/#{h x.id}"%>"><%= h x.name %></a></td>
-          <td><%= (x.aliases - [x.name]).map{|x| "<a href='/#{@project_name}/entities/#{h x.id}'>#{h x.name}</a>" }.join("<br/>") %></td>
+          <td><%= (x.aliases - [x.name]).map{|x| next unless !x.is_ip_address?; "<a href='/#{@project_name}/entities/#{h x.id}'>#{h x.name}</a>" }.join("<br/>") %></td>
           <td><%= h x.details["os"].first["name"] if x.details["os"] && x.details["os"].first %> </td>
           <td><%= h "#{x.details["ports"].map{ |x| x["number"] }.join(", ") if x.details["ports"]}" %></td>
-          <td><%= h "#{x.details["provider"]}"%></td>
+          <td><%= h "#{x.details["net_name"]}"%></td>
+          <td><%= h "#{x.details["geolocation"]["country_code"] if x.details["geolocation"]}"%></td>
         </tr>
       <% end %>
       </tbody>

--- a/lib/issues/leaked_account.rb
+++ b/lib/issues/leaked_account.rb
@@ -9,8 +9,11 @@ class LeakedAccountDetails < BaseIssue
       severity: 2,
       status: "confirmed",
       category: "leak",
-      description: "Related account found leaked",
+      description: "Account found in public leak data",
       remediation: "Leaked accounts should have their passwords reset and examined for suspicious activities.",
+      references: [
+        { type: "description", uri: "https://haveibeenpwned.com/"}
+      ]
     }.merge!(instance_details)
 
   to_return

--- a/lib/issues/leaked_data.rb
+++ b/lib/issues/leaked_data.rb
@@ -11,6 +11,7 @@ class LeakedData< BaseIssue
       category: "leak",
       description: "Related account found leaked",
       remediation: "leaked accounts should be notified to reset their passwords and check for suspicious activities related to their accounts",
+      references: []
     }.merge!(instance_details)
 
   to_return

--- a/lib/tasks/dns_search_sonar.rb
+++ b/lib/tasks/dns_search_sonar.rb
@@ -16,7 +16,7 @@ class DnsSearchSonar < BaseTask
       :allowed_types => ["DnsRecord","Domain"],
       :example_entities => [{"type" => "DnsRecord", "details" => {"name" => "intrigue.io"}}],
       :allowed_options => [
-        {:name => "endpoint", :regex => "alpha_numeric_list", :default => "http://tls.bufferover.run/dns?q=" },
+        {:name => "endpoint", :regex => "alpha_numeric_list", :default => "http://sonar.intrigue.io/dns?q=" },
       ],
       :created_types => ["DnsRecord"]
     }
@@ -28,9 +28,7 @@ class DnsSearchSonar < BaseTask
     endpoint = _get_option("endpoint")
     domain_name = ".#{_get_entity_name}"
     search_url = "#{endpoint}#{domain_name}"
-
     _log_good "Searching data for: #{domain_name}"
-
     
     response = http_request(:get, search_url, nil, {}, nil, 3, 60, 60)
     unless response
@@ -49,7 +47,6 @@ class DnsSearchSonar < BaseTask
           _create_entity "DnsRecord", "name" => entry.split(",").last
         end
       end
-
 
       # Create reverse dns entries
       if json["RDNS"]

--- a/lib/tasks/search_have_i_been_pwned.rb
+++ b/lib/tasks/search_have_i_been_pwned.rb
@@ -16,7 +16,7 @@ class SearchHaveIBeenPwned < BaseTask
         {"type" => "EmailAddress", "details" => {"name" => "nobody@nowhere.com"}}],
       :allowed_options => [
         {:name => "search_breaches", :regex => "boolean", :default => true },
-        {:name => "search_pastes", :regex => "boolean", :default => true },
+        {:name => "search_pastes", :regex => "boolean", :default => false },
         {:name => "only_sensitive", :regex => "boolean", :default => false },
         {:name => "create_issues", :regex => "boolean", :default => true }
       ],
@@ -38,48 +38,29 @@ class SearchHaveIBeenPwned < BaseTask
       return
     end
 
-    _search_pastes_and_create_issues(email_address)
-    _search_breaches_and_create_issues(email_address)
-
+    _search_pastes_and_create_issues(email_address) if _get_option("search_pastes")
+    _search_breaches_and_create_issues(email_address) if _get_option("search_breaches")
   end
-
 
   def _search_pastes_and_create_issues(email_address)
     _log "Searching HIBP Pastes for #{email_address}"
     results = _get_hibp_response("pasteaccount/#{email_address}")
 
     # TODO deal with pagination here
-    if results.count > 0
+    if results
       _log_good "Found #{results.count} paste entries!"
     else
       _log "No results found."
+      return
     end
 
     results.each do |result|
-      _log "Result: #{result}"
-      # create an issue for each found result
-      ############################################
-      ###      Old Issue                      ###
-      ###########################################
-      # _create_issue({
-      #    name: "Email Account Found In Public Paste",
-      #    type: "email_found_in_paste",
-      #    severity: 4,
-      #    status: "confirmed",
-      #    description: "Email account found in paste: #{email_address} in " +
-      #                "#{result["Source"]} on #{result["Date"]} with #{result["EmailCount"] - 1} others.",
-      #    details: result
-      # }) if _get_option("create_issues")
-      ############################################
-      ###      New Issue                      ###
-      ###########################################
+
       _create_linked_issue("leaked_data",{
-         name: "Email Found in Public Paste",
-         type:"leaked_email",
-         severity: 4,
-         detailed_description: "Email account found in paste: #{email_address} in " +
-          "#{result["Source"]} on #{result["Date"]} with #{result["EmailCount"] - 1} others.",
-         references:"https://haveibeenpwned.com/",
+         name: "Email Account Found In HIBP (Public Breach Data)",
+         severity: 3,
+         description: result["Description"],
+         source: result["Name"],
          details: result
       }) if _get_option("create_issues")
     end
@@ -92,42 +73,21 @@ class SearchHaveIBeenPwned < BaseTask
     results = _get_hibp_response("breachedaccount/#{email_address}?truncateResponse=false")
 
     # TODO deal with pagination here
-    if results.count > 0
+    if results
       _log_good "Found #{results.count} breach entries!"
     else
       _log "No results found."
+      return
     end
 
     results.each do |result|
-      _log "Result: #{result}"
       next if _get_option("only_sensitive") && !result["IsSensitive"]
       # create an issue for each found result
-      ############################################
-      ###      Old Issue                      ###
-      ###########################################
-      # _create_issue({
-      #   name: "Email Account Found In Public Breach",
-      #   type: "email_found_in_breach",
-      #   severity: 4,
-      #   status: "confirmed",
-      #   description: "Email account was found in a breach of : #{result["Name"]}\n" +
-      #                 "User: #{email_address} Domain: #{result["Domain"]}.\n" +
-      #                 "The details were leaked on #{result["BreachDate"]} and included #{result["DataClasses"].join(", ")}.\n" +
-      #                 "About this Breach:\n#{result["Description"]}",
-      #   details: result
-      # }) if _get_option("create_issues")
-      ############################################
-      ###      New Issue                      ###
-      ###########################################
       _create_linked_issue("leaked_data",{
-        name: "Email Account Found In Public Breach",
-        type: "leaked_email",
-        severity: 4,
-        detailed_description: "Email account was found in a breach of : #{result["Name"]}\n" +
-          "User: #{email_address} Domain: #{result["Domain"]}.\n" +
-          "The details were leaked on #{result["BreachDate"]} and included #{result["DataClasses"].join(", ")}.\n" +
-          "About this Breach:\n#{result["Description"]}",
-        references:"https://haveibeenpwned.com/",
+        name: "Email Account Found In HIBP (Public Breach Data)",
+        severity: 3,
+        description: result["Description"],
+        source: result["Name"],
         details: result
        }) if _get_option("create_issues")
     end
@@ -136,28 +96,27 @@ class SearchHaveIBeenPwned < BaseTask
   def _get_hibp_response(endpoint)
 
     try_counter = 0
-    max_tries = 9
+    max_tries = 2
+
     begin
       url = "https://haveibeenpwned.com/api/v3/#{endpoint}"
 
       response = nil
       json = nil
 
-
       until json || (try_counter == max_tries)
         try_counter += 1
-        sleep_time = rand(300)
+        sleep_time = rand(20)
 
         response = http_request(:get, url, nil, {
           "hibp-api-key" => @api_key,
-          "User-Agent" => "intrigue-core #{IntrigueApp.version}",
+          "User-Agent" => "intrigue-core 0.7",
           "Accept" => "application/json"
         })
 
-        unless response
-          _log_error "Unable to get response, sleeping #{sleep_time}s"
-          sleep sleep_time
-          next
+        unless response && response.body
+          _log_error "No results!"
+          return
         end
 
         # Okay we got something
@@ -171,35 +130,43 @@ class SearchHaveIBeenPwned < BaseTask
             next
           end
 
-          # okay
-          status_code = json["statuscode"]
-          if status_code.to_i == 429
-            _log_error "Rate limit hit, sleeping #{sleep_time}s"
-            json = nil # reset
-            sleep sleep_time
-          elsif status_code.to_i == 503
-            _log_error "Service unavailable, sleeping #{sleep_time}s"
-            json = nil # reset
-            sleep sleep_time
+          if json.kind_of? Hash
+            # okay
+            status_code = json["statuscode"]
+
+            if status_code && status_code.to_i == 429
+              _log_error "Rate limit hit, sleeping #{sleep_time}s"
+              json = nil # reset
+              sleep sleep_time
+            elsif status_code && status_code.to_i == 503
+              _log_error "Service unavailable, sleeping #{sleep_time}s"
+              json = nil # reset
+              sleep sleep_time
+            elsif status_code && status_code.to_i == 401
+              _log_error "Invalid key?"
+              return
+            end
           end
 
         # in case we can't parse it
         rescue JSON::ParserError => e
-          _log_error "Error retrieving results: #{response}"
-          sleep sleep_time
+          _log_error "Error retrieving JSON results: #{response}, failing"
+          break
         end
 
       end
 
       unless response && json
-        _log "Error! Failing after #{max_tries} attempts to reach the HIBP api"
+        _log "Error! Failed to get results from the HIBP api"
       end
 
     end
 
-  json || []
+  json
   end
 
 end
 end
 end
+
+


### PR DESCRIPTION
This PR brings the HIBP task back to function vs the v3 HIBP api. Issues are now created with a 'source' allowing multiple "leaked_account" issues to be created. 

Additionally, this adjusts the dns_search_sonar task back to our own endpoint, sonar.intrigue.io. 