### PR TITLE
Improve URI (script) metadata collection to determine if scripts are hosted locally or remote

### DIFF
--- a/lib/tasks/enrich/uri.rb
+++ b/lib/tasks/enrich/uri.rb
@@ -69,7 +69,7 @@ class Uri < Intrigue::Task::BaseTask
     script_links = temp_script_links.map { |x| x =~ /^\// ? "#{uri}#{x}" : x }
 
     # parse out the componeents
-    script_components = extract_javascript_components(script_links)
+    script_components = extract_javascript_components(script_links, hostname)
   
     # save the Headers
     headers = []

--- a/lib/tasks/helpers/web_content.rb
+++ b/lib/tasks/helpers/web_content.rb
@@ -3,16 +3,26 @@ module Intrigue
 module Task
 module WebContent
 
-  def extract_javascript_components(script_list)
+  def extract_javascript_components(script_list, host)
     components = []
     script_list.each do |s|
+
+      ### 
+      ### Determine who's hosting
+      ### 
+      if URI.parse(s).host =~ /#{host}/
+        host_location = "local"
+      else
+        host_location = "remote"
+      end
+       
     
       # Try common pattern: "#{name}.#{version}"
       name_version_match = "#{s}".match(/([\w\d]+)\.(\d+\.\d+\.\d+)/i)    
       if (name_version_match && name_version_match.captures)
         name = name_version_match.captures.first.strip
         version = name_version_match.captures.last.strip 
-        components << {"uri" => s, "component" => name.downcase, "version" => version}
+        components << {"uri" => s, "component" => name.downcase, "version" => version, "relative_host" =>  host_location }
         next
       end
       
@@ -21,7 +31,7 @@ module WebContent
       if (name_version_match && name_version_match.captures)
         version = name_version_match.captures.first.strip
         name = name_version_match.captures.last.strip 
-        components << {"uri" => s, "component" => name.downcase, "version" => version}
+        components << {"uri" => s, "component" => name.downcase, "version" => version, "relative_host" =>  host_location }
         next
       end
 
@@ -30,7 +40,7 @@ module WebContent
       if (name_version_match && name_version_match.captures)
         name = name_version_match.captures.first.strip
         version = name_version_match.captures.last.strip 
-        components << {"uri" => s, "component" => name.downcase, "version" => version}
+        components << {"uri" => s, "component" => name.downcase, "version" => version, "relative_host" =>  host_location }
         next
       end
 
@@ -39,7 +49,7 @@ module WebContent
       if (name_version_match && name_version_match.captures)
         name = name_version_match.captures.first.strip
         version = name_version_match.captures.last.strip 
-        components << {"uri" => s, "component" => name.downcase, "version" => version}
+        components << {"uri" => s, "component" => name.downcase, "version" => version, "relative_host" =>  host_location }
         next
       end
 
@@ -48,7 +58,7 @@ module WebContent
       if (name_version_match && name_version_match.captures)
         name = name_version_match.captures.first.strip
         version = name_version_match.captures.last.strip 
-        components << {"uri" => s, "component" => name.downcase, "version" => version}
+        components << {"uri" => s, "component" => name.downcase, "version" => version, "relative_host" =>  host_location }
         next
       end
 
@@ -57,24 +67,24 @@ module WebContent
       if (name_version_match && name_version_match.captures)
         name = name_version_match.captures.first.strip
         version = name_version_match.captures.last.strip 
-        components << {"uri" => s, "component" => name.downcase, "version" => version}
+        components << {"uri" => s, "component" => name.downcase, "version" => version, "relative_host" =>  host_location }
         next
       end
 
       # make sure to capture any specific libs - jquery
       if "#{s}".match(/jquery(\.min)?\.js/i)
-        components << {"uri" => s, "component" => "jquery"}
+        components << {"uri" => s, "component" => "jquery", "relative_host" =>  host_location}
         next
       end
 
       # make sure to capture any specific libs - jquery
       if "#{s}".match(/polyfill(\.min)?\.js/i)
-        components << {"uri" => s, "component" => "polyfill"}
+        components << {"uri" => s, "component" => "polyfill", "relative_host" =>  host_location}
         next
       end
 
-      # otherwise, we didnt find it, so just stick in a url withoout a name
-      components << {"uri" => s }
+      # otherwise, we didnt find it, so just stick in a url withoout a name / version
+      components << {"uri" => s, "relative_host" =>  host_location }
       
     end
 


### PR DESCRIPTION
Quick PR to improve yesterday's spike that enhances metadata around scripts. This PR adds the "relative_host" attribute, which can be either local or remote. Example below: 

```
    {
      "uri": "https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js",
      "version": "1.6.26",
      "component": "webfont",
      "relative_host": "remote"
    },
    {
      "uri": "https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js",
      "version": "3.7.3",
      "component": "html5shiv",
      "relative_host": "remote"
    },
    {
      "uri": "https://www.googletagmanager.com/gtag/js?id=UA-44461955-3",
      "relative_host": "remote"
    },
    {
      "uri": "https://uploads-ssl.webflow.com/5cc1c540144d004204d07f9e/5cf3f26f9af399cb119e0a8e_indigo-white.png",
      "relative_host": "remote"
    },
    {
      "uri": "https://intrigue.io/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js",
      "relative_host": "local"
    },
    {
      "uri": "https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.4.1.min.220afd743d.js?site=5cc1c540144d004204d07f9e",
      "version": "3.4.1",
      "component": "jquery",
      "relative_host": "remote"
    },
    {
      "uri": "https://uploads-ssl.webflow.com/5cc1c540144d004204d07f9e/js/webflow.40d375626.js",
      "relative_host": "remote"
    },
    {
      "uri": "https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js",
      "version": "3.0.2",
      "component": "placeholders",
      "relative_host": "remote"
    },
```