### PR TITLE
Clean up on dependencies, and add a Farsight DNSDB integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'aws-sdk-s3'              #,         '~> 3'
 gem 'aws-sdk-route53'
 gem 'censys',                 :git => 'https://github.com/pentestify/censys.git'
 gem 'cloudflare',             :git => 'https://github.com/intrigueio/cloudflare.git'
-gem 'dnsbl-client',           :git => 'https://github.com/AnasBensalah/dnsbl-client.git'
+gem 'dnsbl-client',           :git => 'https://github.com/intrigueio/dnsbl-client.git'
 gem 'dnsimple'
 gem 'dnsruby'                 # dns_zone_transfer
 gem 'em-resolv-replace'       # dns_brute_sub

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,4 @@
 GIT
-  remote: https://github.com/AnasBensalah/dnsbl-client.git
-  revision: d88bb5eae3dfd03c418f67ae5767234a862a92b8
-  specs:
-    dnsbl-client (1.0.4)
-
-GIT
   remote: https://github.com/NeutrinoAPI/NeutrinoAPI-Ruby.git
   revision: b2d0648773bc852d75ab41c321b55695b690e131
   specs:
@@ -32,8 +26,14 @@ GIT
       async-rest (~> 0.10.0)
 
 GIT
+  remote: https://github.com/intrigueio/dnsbl-client.git
+  revision: d88bb5eae3dfd03c418f67ae5767234a862a92b8
+  specs:
+    dnsbl-client (1.0.4)
+
+GIT
   remote: https://github.com/intrigueio/intrigue-ident.git
-  revision: 521161b65c3f5a8e45aa75a8f112030eb1701e38
+  revision: f5cb802e31070a9edfd2f1befa402e31123f64fd
   specs:
     intrigue-ident (0.9.3)
       snmp
@@ -111,50 +111,50 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.2.2)
+    activesupport (6.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    async (1.25.2)
+    async (1.26.1)
       console (~> 1.0)
       nio4r (~> 2.3)
       timers (~> 4.1)
-    async-http (0.52.0)
+    async-http (0.52.3)
       async (~> 1.25)
       async-io (~> 1.28)
       async-pool (~> 0.2)
-      protocol-http (~> 0.18.0)
-      protocol-http1 (~> 0.12.0)
+      protocol-http (~> 0.20.0)
+      protocol-http1 (~> 0.13.0)
       protocol-http2 (~> 0.14.0)
     async-io (1.29.0)
       async (~> 1.14)
-    async-pool (0.3.0)
+    async-pool (0.3.1)
       async (~> 1.25)
     async-rest (0.10.1)
       async-http (~> 0.42)
       protocol-http (~> 0.7)
     aws-eventstream (1.1.0)
-    aws-partitions (1.306.0)
-    aws-sdk-core (3.94.0)
+    aws-partitions (1.314.0)
+    aws-sdk-core (3.95.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.30.0)
+    aws-sdk-kms (1.31.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-route53 (1.33.0)
+    aws-sdk-route53 (1.34.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.63.0)
+    aws-sdk-s3 (1.64.0)
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.24.0)
+    aws-sdk-sqs (1.25.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.3)
@@ -226,7 +226,7 @@ GEM
     foreman (0.87.1)
     formatador (0.2.5)
     god (0.13.7)
-    google-api-client (0.38.0)
+    google-api-client (0.39.2)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.9)
       httpclient (>= 2.8.1, < 3.0)
@@ -240,7 +240,7 @@ GEM
     google-cloud-env (1.3.1)
       faraday (>= 0.17.3, < 2.0)
     google-cloud-errors (1.0.0)
-    google-cloud-storage (1.26.0)
+    google-cloud-storage (1.26.1)
       addressable (~> 2.5)
       digest-crc (~> 0.4)
       google-api-client (~> 0.33)
@@ -283,7 +283,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0425)
+    mime-types-data (3.2020.0512)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -304,9 +304,9 @@ GEM
     pg (1.2.3)
     power_assert (1.2.0)
     protocol-hpack (1.4.2)
-    protocol-http (0.18.0)
-    protocol-http1 (0.12.0)
-      protocol-http (~> 0.18)
+    protocol-http (0.20.0)
+    protocol-http1 (0.13.0)
+      protocol-http (~> 0.19)
     protocol-http2 (0.14.0)
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.18)
@@ -316,7 +316,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    public_suffix (4.0.4)
+    public_suffix (4.0.5)
     puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.2.2)
@@ -326,7 +326,7 @@ GEM
       rack (>= 1.0, < 3)
     rake (13.0.1)
     rb-readline (0.5.5)
-    redis (4.1.3)
+    redis (4.1.4)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
     representable (3.0.4)
@@ -349,27 +349,27 @@ GEM
     rex-core (0.1.13)
     rex-socket (0.1.23)
       rex-core
-    rex-text (0.2.25)
+    rex-text (0.2.26)
     rkelly-remix (0.0.7)
     rprogram (0.3.2)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.1)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
+    rspec-support (3.9.3)
     ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
-    sequel (5.31.0)
+    sequel (5.32.0)
     shodan (1.0.0)
       json (>= 1.4.6)
     sidekiq (6.0.7)
@@ -424,7 +424,7 @@ GEM
       activesupport (>= 4)
       whois (>= 4.0.7)
     yajl-ruby (1.4.1)
-    yard (0.9.24)
+    yard (0.9.25)
     zeitwerk (2.3.0)
 
 PLATFORMS

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -299,12 +299,13 @@ module Intrigue
               #:task_type => t.task_type,
               :base_entity_name => t.base_entity.name,
               :base_entity_type => t.base_entity.type  }
-          }
+          }, 
+          :generated_at => Time.now.utc
         }
       end
 
       def export_json
-        export_hash.merge("generated_at" => "#{Time.now.utc}").to_json
+        export_hash.to_json
       end
 
       def export_csv

--- a/lib/initialize/json_export_file.rb
+++ b/lib/initialize/json_export_file.rb
@@ -9,7 +9,7 @@
 class JsonExportFile
 
   def initialize(fullpath=nil)
-    @output_file = fullpath || "#{$intrigue_basedir}/tmp/#{rand(100000000000)}.json"
+    @output_file = fullpath || "#{$intrigue_basedir}/tmp/json_export_#{rand(100000000000)}.json"
     @entity_count = 0
     @closed = false
 

--- a/lib/tasks/nmap_scan.rb
+++ b/lib/tasks/nmap_scan.rb
@@ -96,7 +96,7 @@ class NmapScan < BaseTask
         end
 
         # either way, set os details from nmap
-        ip_entity.set_detail("os", host.os.matches)
+        ip_entity.set_detail("os", host.os.matches) if host.os
 
         # create an array to save all port details for this host
         host_details = []

--- a/lib/tasks/search_farsight_dnsdb.rb
+++ b/lib/tasks/search_farsight_dnsdb.rb
@@ -1,0 +1,71 @@
+module Intrigue
+  module Task
+  class SearchFarsightDnsdb < BaseTask
+  
+    def self.metadata
+      {
+        :name => "search_farsight_dnsdb",
+        :pretty_name => "Search Farsight DNSDB",
+        :authors => ["jcran"],
+        :description => "This task searches DNSDB by domain.",
+        :references => [],
+        :type => "discovery",
+        :passive => true,
+        :allowed_types => ["Domain"],
+        :example_entities => [
+          {"type" => "DnsRecord", "details" => {"name" => "intrigue.io"}}
+        ],
+        :allowed_options => [],
+        :created_types => ["*"]
+      }
+    end
+  
+    ## Default method, subclasses must override this
+    def run
+      super
+  
+      name = _get_entity_name
+      api_key = _get_task_config("farsight_dnsdb_api_key")
+      api_endpoint = "https://api.dnsdb.info/"
+
+      #curl -i -H 'Accept: application/json' -H "" 
+
+      headers = {"Accept" => "application/json", "X-API-Key" => api_key }
+      
+      #returns json, one per line 
+      out = http_get_body("#{api_endpoint}/lookup/rrset/name/\*.#{_get_entity_name}?limit=0", nil, headers)
+      
+      if out && out.kind_of?(String) && !out =~/^Error:/
+
+        out.split("\n").each do |line|
+          begin
+            
+            # parse the line into a record 
+            record = JSON.parse(line)
+
+            # grab the dns name, remove trailing space and wildcards
+            create_dns_entity_from_string dns_name
+  
+            # Parse up the data 
+            rdata = record["rdata"]
+            rdata.each do |dns_data|
+              if !dns_data.split(" ").length > 1  # skip txt records and such
+                create_dns_entity_from_string dns_data  
+              end
+            end
+
+          rescue JSON::ParserError => e
+            _log_error "Unable to parse line: #{line.first(50)}!"
+          end  
+        end
+
+      else 
+        _log_error "unable to parse result: #{out}"
+      end
+
+    end
+
+  end
+  end
+  end
+  


### PR DESCRIPTION
Farsight DNSDB is a Passive DNS (pDNS) historical database that provides a unique, fact-based, multifaceted view of the configuration of the global Internet infrastructure DNSDB leverages the richness of Farsight’s Security Information Exchange (SIE) data-sharing platform and is engineered and operated by leading DNS experts.

Also fixes a bug in the nmap_scan task in (rare?) cases where we don't have an OS field in the output. 