### PR TITLE
NetworkService fingerprinting 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GIT
 
 GIT
   remote: https://github.com/intrigueio/intrigue-ident.git
-  revision: 937d928b21bd33360335f9398a452053fcb6b149
+  revision: 840bfa7745e7f9ebf10ae8054c6bff814931f7f6
   specs:
     intrigue-ident (0.9.3)
       snmp

--- a/app/api/v1/task_result.rb
+++ b/app/api/v1/task_result.rb
@@ -24,9 +24,12 @@ class IntrigueApp < Sinatra::Base
     # optional / defaulted parameters
     entity_details = payload[:entity_details] || {}
     task_options = payload[:task_options] || {}
-    depth = payload[:depth] || 1
+    
     handler_names = "#{payload[:handler_names]}".split(",") || []
+    
     machine_name = payload[:machine_name] || nil
+    machine_depth = payload[:machine_depth] || 1
+
     auto_enrich = payload[:auto_enrich] || true
     auto_scope = payload[:auto_scope] || false
     queue_name = payload[:queue_name] || "task"
@@ -52,7 +55,7 @@ class IntrigueApp < Sinatra::Base
 
     # Start the task_run
     scan_result_id = nil # only applicable if we're called from a machine
-    task_result = start_task(queue_name, project_object, scan_result_id, task_name, entity_object, depth,
+    task_result = start_task(queue_name, project_object, scan_result_id, task_name, entity_object, machine_depth,
                                 task_options, handler_names, machine_name, auto_enrich, auto_scope)
 
     # manually start enrichment, since we've already created the entity above, it won't auto-enrich ^

--- a/lib/entities/mailserver.rb
+++ b/lib/entities/mailserver.rb
@@ -1,0 +1,41 @@
+module Intrigue
+  module Entity
+  class Mailserver < Intrigue::Model::Entity
+  
+    include Intrigue::Task::Dns
+  
+    def self.metadata
+      {
+        :name => "Mailserver",
+        :description => "A Mailserver (MX)",
+        :user_creatable => true,
+        :example => "ns1.intrigue.io"
+      }
+    end
+  
+    def validate_entity
+      return ( name =~ ipv4_regex || name =~ ipv6_regex || name =~ dns_regex )
+    end
+  
+    def enrichment_tasks
+      ["enrich/mailserver"]
+    end
+  
+      ###
+    ### SCOPING
+    ###
+    def scoped?(conditions={}) 
+      return true if self.seed
+      return false if self.hidden # hit our blacklist so definitely false
+  
+      # check hidden on-demand
+      return true if self.project.traversable_entity?(parse_domain_name(self.name), "Domain")
+  
+    # if we didnt match the above and we were asked, it's false 
+    false
+    end
+  
+  end
+  end
+  end
+  

--- a/lib/entities/nameserver.rb
+++ b/lib/entities/nameserver.rb
@@ -27,15 +27,7 @@ class Nameserver < Intrigue::Model::Entity
   def scoped?(conditions={}) 
     return true if self.seed
     return false if self.hidden # hit our blacklist so definitely false
-
-    #
-    # Check types we'll check for indicators of in-scope-ness
-    #scope_check_entity_types = [ "Intrigue::Entity::Domain" ]
-
-    #self.project.seeds.each do |s|
-    #  return true if s.name =~ /#{parse_domain_name(self.name)}/i
-    #end
-
+    
     # check hidden on-demand
     return true if self.project.traversable_entity?(parse_domain_name(self.name), "Domain")
 

--- a/lib/tasks/enrich/mailserver.rb
+++ b/lib/tasks/enrich/mailserver.rb
@@ -1,0 +1,72 @@
+module Intrigue
+  module Task
+  module Enrich
+  class Mailserver < Intrigue::Task::BaseTask
+  
+    def self.metadata
+      {
+        :name => "enrich/mailserver",
+        :pretty_name => "Enrich Mailserver",
+        :authors => ["jcran"],
+        :description => "Enrich a mailserver entity",
+        :references => [],
+        :allowed_types => ["Mailserver"],
+        :type => "enrichment",
+        :passive => true,
+        :example_entities => [{"type" => "Mailserver", "details" => {"name" => "mx.intrigue.io"}}],
+        :allowed_options => [],
+        :created_types => []
+      }
+    end
+  
+    def run
+      super
+      _log "Enriching... Nameserver: #{_get_entity_name}"
+  
+
+      # Use intrigue-ident code to request the banner and fingerprint
+      _log "Grabbing banner and fingerprinting!"
+      ident_matches = generate_smtp_request_and_check(_get_entity_name) || {}
+      ident_fingerprints = ident_matches["fingerprints"]
+      _log "Got #{ident_fingerprints.count} fingerprints!"
+
+      # get the request/response we made so we can keep track of redirects
+      ident_banner = ident_matches["banner"]
+
+      if ident_fingerprints.count > 0
+
+        # Make sure the key is set before querying intrigue api
+        intrigueio_api_key = _get_task_config "intrigueio_api_key"
+        use_api = intrigueio_api_key && intrigueio_api_key.length > 0
+
+        # for ech fingerprint, map vulns 
+        ident_fingerprints = ident_fingerprints.map do |fp|
+
+          vulns = []
+          if fp["inference"]
+            cpe = Intrigue::Vulndb::Cpe.new(fp["cpe"])
+            if use_api # get vulns via intrigue API
+              _log "Matching vulns for #{fp["cpe"]} via Intrigue API"
+              vulns = cpe.query_intrigue_vulndb_api(intrigueio_api_key)
+            else
+              vulns = cpe.query_local_nvd_json
+            end
+          else
+            _log "Skipping inference on #{fp["cpe"]}"
+          end
+
+          fp.merge!({ "vulns" => vulns })
+        end
+
+      end
+
+      _set_entity_detail "banner", ident_banner
+      _set_entity_detail "fingerprint", ident_fingerprints
+
+
+    end # end run
+  
+  end
+  end
+  end
+  end


### PR DESCRIPTION
Currently supported protocols:
 - SSH
 - FTP
 - SNMP
 - TELNET
 - SNMP

Note that vulnerability inference will "just work" with this, provided a check fires, and the :inference attribute is present and 'true'.

A next step for this work is to get #120 hooked up for these protocols. It's currently unclear if the grabbers will live in ident or core long term.  Uri fingerprinting remains independent at this time.  

Example of this in practice: 
![image](https://user-images.githubusercontent.com/76854/83464653-28082380-a437-11ea-9318-a6743ddf6d58.png)
