### PR TITLE
adding "search_dshield" task for checking ip reputation and threat fe…

### DIFF
--- a/lib/tasks/threat/search_dshield.rb
+++ b/lib/tasks/threat/search_dshield.rb
@@ -1,0 +1,54 @@
+module Intrigue
+module Task
+class SearchDshield < BaseTask
+
+
+  def self.metadata
+    {
+      :name => "threat/search_dshield",
+      :pretty_name => "Threat Check - Search Dshield",
+      :authors => ["Anas Ben Salah"],
+      :description => "This task hits Dshield api for Ip reputation and threat feeds ",
+      :references => ["https://www.dshield.org/api/#ip"],
+      :type => "threat_check",
+      :passive => true,
+      :allowed_types => ["IpAddress"],
+      :example_entities => [{"type" => "IpAddress", "details" => {"name" => "1.1.1.1"}}],
+      :allowed_options => [],
+      :created_types => []
+    }
+  end
+
+
+  ## Default method, subclasses must override this
+  def run
+    super
+
+      #get entity name and type
+      entity_name = _get_entity_name
+
+      #headers
+      headers = { "Accept" =>  "application/json"}
+
+      # Get responce
+      response = http_get_body("https://www.dshield.org/api/ip/#{entity_name}?json",nil,headers)
+      result = JSON.parse(response)
+
+      if result["attacks"] != "null" or result["maxrisk"] != "null"
+        _create_linked_issue("suspicious_activity_detected", {
+          status: "confirmed",
+          description: "This ip was flagged by Dshield for malicious activites",
+          fraudguard_details: result,
+          source: "Dshield.org"
+        })
+        # Also store it on the entity
+        blocked_list = @entity.get_detail("suspicious_activity_detected") || []
+        @entity.set_detail("suspicious_activity_detected", blocked_list.concat([{}]))
+    end
+  end #end run
+
+
+
+end
+end
+end


### PR DESCRIPTION
This task hits Dshield.org API for IP reputation and threat feeds. 

DShield returns a summary of the information from its database holds for a particular IP address, including many fields related to general IP info like: 
- AS 
- AS Name
- AS Size
- AS Country
- Network
- ...

Also, threat feeds like: 

- Count (include the total number of packets blocked from this IP) 
- Attacks: (number of unique destination IP addresses of these packets) 
- Threat feeds sources 
- Maxrisk score 
- Abuse contact

when the IP address hits one threat feeds fields it triggers an alert showing all the details that we mentioned previously 
[This screenshot  is an example showing how search DShield works]  
![image](https://user-images.githubusercontent.com/35723779/83558700-51927f00-a50b-11ea-9286-4ab437d05329.png)

![image](https://user-images.githubusercontent.com/35723779/83559020-cfef2100-a50b-11ea-8abb-d34a1f90dc36.png)
