### PR TITLE
adding search spyse cert for discovering domains registered with the same certificate

### DIFF
--- a/lib/tasks/search_spyse.rb
+++ b/lib/tasks/search_spyse.rb
@@ -33,58 +33,36 @@ class SearchSpyse < BaseTask
     if entity_type == "IpAddress"
       #search Ip for reputation, Open ports, related information
       search_ip_reputation entity_name,headers
+      search_open_ports entity_name,headers
     else
       _log_error "Unsupported entity type"
     end
 
-  end #end run
+  end #end
 
-  #Lists open ports on IP
-  # def search_ip_port(entity_name, headers)
-  #
-  #   # Set the headers
-  #   url = "https://api.spyse.com/v2/data/ip/port?limit=100&ip=#{entity_name}"
-  #
-  #   # make the request
-  #   response = http_get_body(url,nil,headers)
-  #   json = JSON.parse(response)
-  #   #puts json
-  #   json["data"]["items"].each do |result|
-  #       puts "#{entity_name}: #{result["port"]}"
-  #     if result["service"] == ""
-  #
-  #     #_create_entity("IpAddress", {"name" => entity_name, "open_port" => result["port"] , "service" => result["service"]})
-  #       _log_good "Creating service on #{entity_name}: #{result["port"]}"
-  #       _create_network_service_entity(@entity, result["port"])
-  #     else
-  #       _log_good "Creating service on #{entity_name}: #{result["port"]}"
-  #       _create_network_service_entity(@entity, result["port"],result["service"])
-  #     end
-  #   end
-  # end
-
-  #search IP
+  # Search IP reputation and gathering data
   def search_ip_reputation(entity_name, headers)
 
-    # Set the headers
+    # Set the URL for ip data
     url = "https://api.spyse.com/v2/data/ip?limit=100&ip=#{entity_name}"
 
     # make the request
     response = http_get_body(url,nil,headers)
     json = JSON.parse(response)
-    #puts json
-    json["data"]["items"].each do |result|
-      # #create physical location
-      # if result["maxmind_geo"]["country"]
-        # puts result["maxmind_geo"]["country"]
-         #_create_entity("PhysicalLocation", "name" => result["maxmind_geo"]["country"])
-      # end
-      # # Create list of related organizations
-      # if result["maxmind_isp"]["org"]
-         #puts result["maxmind_isp"]["org"]
-         #_create_entity("Organization", "name" => result["entity"]["organization"])
-      # end
 
+    json["data"]["items"].each do |result|
+
+      # Create physical location
+      if result["maxmind_geo"]["country"]
+        _create_entity("PhysicalLocation", "name" => result["maxmind_geo"]["country"], "extended_spyse" => result["maxmind_geo"])
+      end
+
+      # Getting ISP organization
+      if result["maxmind_isp"]["org"]
+        _create_entity("Organization", "name" => result["maxmind_isp"]["org"], "extended_spyse" => result["maxmind_isp"])
+      end
+
+      # Create an issue if result score indicates a score related to the threat
       if result["score"] < 100
         _create_linked_issue("suspicious_activity_detected",{
           severity: result["score"],
@@ -94,23 +72,23 @@ class SearchSpyse < BaseTask
         })
       end
     end
-    # Search for open ports
+  end
+
+  # Search for open ports
+  def search_open_ports entity_name, headers
+
+    # Set the URL for ip open ports
     url2 = "https://api.spyse.com/v2/data/ip/port?limit=100&ip=#{entity_name}"
 
     # make the request
     response2 = http_get_body(url2,nil,headers)
     json2 = JSON.parse(response2)
-    #puts json
+
     json2["data"]["items"].each do |result|
-        puts "#{entity_name}:#{result["port"]}"
-      #_create_entity("IpAddress", {"name" => entity_name, "open_port" => result["port"] , "service" => result["service"]})
-        _log_good "Creating service on #{entity_name}: #{result["port"]}"
-        _create_network_service_entity(@entity, result["port"])
+      _log_good "Creating service on #{entity_name}: #{result["port"]}"
+      _create_network_service_entity(@entity, result["port"],protocol="tcp",generic_details={"extended_spyse" => result})
     end
   end
-
-  
-
 
 end
 end

--- a/lib/tasks/search_spyse.rb
+++ b/lib/tasks/search_spyse.rb
@@ -11,8 +11,8 @@ class SearchSpyse < BaseTask
       :references => ["https://spyse.com/apidocs"],
       :type => "discovery",
       :passive => true,
-      :allowed_types => ["String", "Domain"],
-      :example_entities => [{"type" => "String", "details" => {"name" => "jira"}}],
+      :allowed_types => ["IpAddress","String", "Domain"],
+      :example_entities => [{"type" => "String", "details" => {"name" => "1.1.1.1"}}],
       :allowed_options => [],
       :created_types => ["DnsRecord","IpAddress","Organization","PhysicalLocation"]
     }
@@ -28,64 +28,89 @@ class SearchSpyse < BaseTask
     # Make sure the key is set
     api_key = _get_task_config("spyse_api_key")
     # Set the headers
-    headers = {"api_token" =>  api_key}
+    headers = { "Accept" =>  "application/json" , "Authorization" => "Bearer #{api_key}" }
 
-    # Returns aggregate information by subdomain word : total count of subdomains, list of IPs of subdomains and subdomain count on every IP,
-    # list of countries and subdomain count from it, list of CIDRs /24, /16 and subdomain list on every CIDR.
-    if entity_type == "String"
-      url = "https://api.spyse.com/v1/domains-starts-with-aggregate?sdword=#{entity_name}"
-      get_subdomains entity_name, api_key, headers, url
-
-    # Returns aggregate information by domain: total count of subdomains, list of IPs of subdomains and subdomain count on every IP,
-    # list of countries and subdomain count from it, list of CIDRs /24, /16 and subdomain list on every CIDR.
-    elsif entity_type == "Domain"
-      url = "https://api.spyse.com/v1//subdomains-aggregate?domain=#{entity_name}"
-      get_subdomains entity_name, api_key, headers, url
-
+    if entity_type == "IpAddress"
+      #search Ip for reputation, Open ports, related information
+      search_ip_reputation entity_name,headers
     else
       _log_error "Unsupported entity type"
     end
 
   end #end run
 
+  #Lists open ports on IP
+  # def search_ip_port(entity_name, headers)
+  #
+  #   # Set the headers
+  #   url = "https://api.spyse.com/v2/data/ip/port?limit=100&ip=#{entity_name}"
+  #
+  #   # make the request
+  #   response = http_get_body(url,nil,headers)
+  #   json = JSON.parse(response)
+  #   #puts json
+  #   json["data"]["items"].each do |result|
+  #       puts "#{entity_name}: #{result["port"]}"
+  #     if result["service"] == ""
+  #
+  #     #_create_entity("IpAddress", {"name" => entity_name, "open_port" => result["port"] , "service" => result["service"]})
+  #       _log_good "Creating service on #{entity_name}: #{result["port"]}"
+  #       _create_network_service_entity(@entity, result["port"])
+  #     else
+  #       _log_good "Creating service on #{entity_name}: #{result["port"]}"
+  #       _create_network_service_entity(@entity, result["port"],result["service"])
+  #     end
+  #   end
+  # end
 
-  # Returns aggregate information by subdomain word and domain
-  def get_subdomains entity_name, api_key, headers, url
+  #search IP
+  def search_ip_reputation(entity_name, headers)
 
+    # Set the headers
+    url = "https://api.spyse.com/v2/data/ip?limit=100&ip=#{entity_name}"
+
+    # make the request
     response = http_get_body(url,nil,headers)
     json = JSON.parse(response)
+    #puts json
+    json["data"]["items"].each do |result|
+      # #create physical location
+      # if result["maxmind_geo"]["country"]
+        # puts result["maxmind_geo"]["country"]
+         #_create_entity("PhysicalLocation", "name" => result["maxmind_geo"]["country"])
+      # end
+      # # Create list of related organizations
+      # if result["maxmind_isp"]["org"]
+         #puts result["maxmind_isp"]["org"]
+         #_create_entity("Organization", "name" => result["entity"]["organization"])
+      # end
 
-    #check if entries different to null
-    if json["count"] != 0
-      # Create subdomains
-      json["cidr"]["cidr16"]["results"].each do |e|
-        e["data"]["domains"].each do |s|
-          _create_entity("DnsRecord", "name" => s)
-        end
-      end
-     # Create subdomains
-      json["cidr"]["cidr24"]["results"].each do |e|
-        e["data"]["domains"].each do |s|
-          _create_entity("DnsRecord", "name" => s)
-        end
-      end
-
-      # Create list of related organizations
-      json["data"]["as"]["results"].each do |e|
-        _create_entity("Organization", "name" => e["entity"]["organization"])
-      end
-
-      # Create list of related countrys
-      json["data"]["country"]["results"].each do |e|
-        _create_entity("PhysicalLocation", "name" => e["entity"]["value"])
-      end
-
-      # Create list of related IPs
-      json["data"]["ip"]["results"].each do |e|
-        _create_entity("IpAddress", "name" => e["entity"]["value"])
+      if result["score"] < 100
+        _create_linked_issue("suspicious_activity_detected",{
+          severity: result["score"],
+          references: ["https://spyse.com/"],
+          source:"Spyse",
+          details: result
+        })
       end
     end
-  end #end subdomain
+    # Search for open ports
+    url2 = "https://api.spyse.com/v2/data/ip/port?limit=100&ip=#{entity_name}"
+
+    # make the request
+    response2 = http_get_body(url2,nil,headers)
+    json2 = JSON.parse(response2)
+    #puts json
+    json2["data"]["items"].each do |result|
+        puts "#{entity_name}:#{result["port"]}"
+      #_create_entity("IpAddress", {"name" => entity_name, "open_port" => result["port"] , "service" => result["service"]})
+        _log_good "Creating service on #{entity_name}: #{result["port"]}"
+        _create_network_service_entity(@entity, result["port"])
+    end
+  end
+
+  
+
 
 end
 end

--- a/lib/tasks/search_spyse_cert.rb
+++ b/lib/tasks/search_spyse_cert.rb
@@ -43,7 +43,7 @@ class SearchSpyseCert < BaseTask
   def search_domain_registered_with_same_cert(entity_name, headers)
 
     # Set the headers
-    url = "https://api.spyse.com/v2/data/cert?limit=100&hash=#{entity_name}"
+    url = "https://api.spyse.com/v3/data/cert?limit=100&hash=#{entity_name}"
 
     # make the request
     response = http_get_body(url,nil,headers)
@@ -73,7 +73,7 @@ class SearchSpyseCert < BaseTask
           _create_entity("Organization", {"name" => organization })
         end
       end
-      
+
     end
   end #end search_domain_registered_with_same_cert
 

--- a/lib/tasks/search_spyse_cert.rb
+++ b/lib/tasks/search_spyse_cert.rb
@@ -1,0 +1,82 @@
+module Intrigue
+module Task
+class SearchSpyseCert < BaseTask
+
+  def self.metadata
+    {
+      :name => "search_spyse_cert",
+      :pretty_name => "Search Spyse Cert",
+      :authors => ["Anas Ben Salah"],
+      :description => "This task hits Spyse API for discovring domains registered with the same certificate",
+      :references => ["https://spyse.com/apidocs"],
+      :type => "discovery",
+      :passive => true,
+      :allowed_types => ["SslCertificate"],
+      :example_entities => [{"type" => "String", "details" => {"name" => "intrigue.io"}}],
+      :allowed_options => [],
+      :created_types => ["DnsRecord","Organization","PhysicalLocation"]
+    }
+  end
+
+  ## Default method, subclasses must override this
+  def run
+    super
+
+    entity_name = _get_entity_name
+    entity_type = _get_entity_type_string
+
+    # Make sure the key is set
+    api_key = _get_task_config("spyse_api_key")
+    # Set the headers
+    headers = { "Accept" =>  "application/json" , "Authorization" => "Bearer #{api_key}" }
+
+    if entity_type == "SslCertificate"
+      #search Ip for reputation, Open ports, related information
+      search_domain_registered_with_same_cert entity_name,headers
+    else
+      _log_error "Unsupported entity type"
+    end
+
+  end #end run
+
+  # search for domains registred with same certificate
+  def search_domain_registered_with_same_cert(entity_name, headers)
+
+    # Set the headers
+    url = "https://api.spyse.com/v2/data/cert?limit=100&hash=#{entity_name}"
+
+    # make the request
+    response = http_get_body(url,nil,headers)
+    json = JSON.parse(response)
+    #puts json
+
+    #create an issue if many domains founded registered with same Certificate
+    json["data"]["items"].each do |result|
+      if result["parsed"]["names"]
+        _create_linked_issue("domains_registered_with_same_certificate",{
+          references: ["https://spyse.com/"],
+          source:"Spyse",
+          details: result["parsed"]
+        })
+      end
+
+      #create DnsRecord from domains registered with same certificate
+      if result["parsed"]["names"]
+        result["parsed"]["names"].each do |domain|
+          _create_entity("DnsRecord", {"name" => domain })
+        end
+      end
+
+      #create organizations related to the certificate
+      if result["parsed"]["subject"]["organization"]
+        result["parsed"]["subject"]["organization"].each do |organization|
+          _create_entity("Organization", {"name" => organization })
+        end
+      end
+      
+    end
+  end #end search_domain_registered_with_same_cert
+
+end
+end
+end

--- a/lib/tasks/threat/search_dshield.rb
+++ b/lib/tasks/threat/search_dshield.rb
@@ -1,0 +1,54 @@
+module Intrigue
+module Task
+class SearchDshield < BaseTask
+
+
+  def self.metadata
+    {
+      :name => "threat/search_dshield",
+      :pretty_name => "Threat Check - Search Dshield",
+      :authors => ["Anas Ben Salah"],
+      :description => "This task hits Dshield api for Ip reputation and threat feeds ",
+      :references => ["https://www.dshield.org/api/#ip"],
+      :type => "threat_check",
+      :passive => true,
+      :allowed_types => ["IpAddress"],
+      :example_entities => [{"type" => "IpAddress", "details" => {"name" => "1.1.1.1"}}],
+      :allowed_options => [],
+      :created_types => []
+    }
+  end
+
+
+  ## Default method, subclasses must override this
+  def run
+    super
+
+      #get entity name and type
+      entity_name = _get_entity_name
+
+      #headers
+      headers = { "Accept" =>  "application/json"}
+
+      # Get responce
+      response = http_get_body("https://www.dshield.org/api/ip/#{entity_name}?json",nil,headers)
+      result = JSON.parse(response)
+
+      if result["attacks"] != "null" or result["maxrisk"] != "null"
+        _create_linked_issue("suspicious_activity_detected", {
+          status: "confirmed",
+          description: "This ip was flagged by Dshield for malicious activites",
+          fraudguard_details: result,
+          source: "Dshield.org"
+        })
+        # Also store it on the entity
+        blocked_list = @entity.get_detail("suspicious_activity_detected") || []
+        @entity.set_detail("suspicious_activity_detected", blocked_list.concat([{}]))
+    end
+  end #end run
+
+
+
+end
+end
+end


### PR DESCRIPTION
Spyse holds one of the largest database containing a wide range of OSINT data handy for the reconnaissance

This task hits spyse.com API for discovering domains registered with the same certificate

Many domains founded, registered with the same certificate this may lead to asset discovery and easy enumeration by attackers

Domains must be registered with different certificates for security reasons to avoid exposing all company resources and websites 

demo: 
[screenshot: general results]
![image](https://user-images.githubusercontent.com/35723779/84211004-2cc17d00-aab2-11ea-80f8-80d3b70409e7.png)
[screenshot: issue creation]
![image](https://user-images.githubusercontent.com/35723779/84211101-6c886480-aab2-11ea-85f3-be9026422a56.png)
![image](https://user-images.githubusercontent.com/35723779/84211118-79a55380-aab2-11ea-9a69-b8c54d39e487.png)
  