### PR TITLE
Adding "Search Spyse Domain" for listing all subdomains related to the seed also listing domain sharing the same IP 

### DIFF
--- a/lib/tasks/search_spyse.rb
+++ b/lib/tasks/search_spyse.rb
@@ -33,58 +33,36 @@ class SearchSpyse < BaseTask
     if entity_type == "IpAddress"
       #search Ip for reputation, Open ports, related information
       search_ip_reputation entity_name,headers
+      search_open_ports entity_name,headers
     else
       _log_error "Unsupported entity type"
     end
 
-  end #end run
+  end #end
 
-  #Lists open ports on IP
-  # def search_ip_port(entity_name, headers)
-  #
-  #   # Set the headers
-  #   url = "https://api.spyse.com/v2/data/ip/port?limit=100&ip=#{entity_name}"
-  #
-  #   # make the request
-  #   response = http_get_body(url,nil,headers)
-  #   json = JSON.parse(response)
-  #   #puts json
-  #   json["data"]["items"].each do |result|
-  #       puts "#{entity_name}: #{result["port"]}"
-  #     if result["service"] == ""
-  #
-  #     #_create_entity("IpAddress", {"name" => entity_name, "open_port" => result["port"] , "service" => result["service"]})
-  #       _log_good "Creating service on #{entity_name}: #{result["port"]}"
-  #       _create_network_service_entity(@entity, result["port"])
-  #     else
-  #       _log_good "Creating service on #{entity_name}: #{result["port"]}"
-  #       _create_network_service_entity(@entity, result["port"],result["service"])
-  #     end
-  #   end
-  # end
-
-  #search IP
+  # Search IP reputation and gathering data
   def search_ip_reputation(entity_name, headers)
 
-    # Set the headers
+    # Set the URL for ip data
     url = "https://api.spyse.com/v2/data/ip?limit=100&ip=#{entity_name}"
 
     # make the request
     response = http_get_body(url,nil,headers)
     json = JSON.parse(response)
-    #puts json
-    json["data"]["items"].each do |result|
-      # #create physical location
-      # if result["maxmind_geo"]["country"]
-        # puts result["maxmind_geo"]["country"]
-         #_create_entity("PhysicalLocation", "name" => result["maxmind_geo"]["country"])
-      # end
-      # # Create list of related organizations
-      # if result["maxmind_isp"]["org"]
-         #puts result["maxmind_isp"]["org"]
-         #_create_entity("Organization", "name" => result["entity"]["organization"])
-      # end
 
+    json["data"]["items"].each do |result|
+
+      # Create physical location
+      if result["maxmind_geo"]["country"]
+        _create_entity("PhysicalLocation", "name" => result["maxmind_geo"]["country"], "extended_spyse" => result["maxmind_geo"])
+      end
+
+      # Getting ISP organization
+      if result["maxmind_isp"]["org"]
+        _create_entity("Organization", "name" => result["maxmind_isp"]["org"], "extended_spyse" => result["maxmind_isp"])
+      end
+
+      # Create an issue if result score indicates a score related to the threat
       if result["score"] < 100
         _create_linked_issue("suspicious_activity_detected",{
           severity: result["score"],
@@ -94,23 +72,23 @@ class SearchSpyse < BaseTask
         })
       end
     end
-    # Search for open ports
+  end
+
+  # Search for open ports
+  def search_open_ports entity_name, headers
+
+    # Set the URL for ip open ports
     url2 = "https://api.spyse.com/v2/data/ip/port?limit=100&ip=#{entity_name}"
 
     # make the request
     response2 = http_get_body(url2,nil,headers)
     json2 = JSON.parse(response2)
-    #puts json
+
     json2["data"]["items"].each do |result|
-        puts "#{entity_name}:#{result["port"]}"
-      #_create_entity("IpAddress", {"name" => entity_name, "open_port" => result["port"] , "service" => result["service"]})
-        _log_good "Creating service on #{entity_name}: #{result["port"]}"
-        _create_network_service_entity(@entity, result["port"])
+      _log_good "Creating service on #{entity_name}: #{result["port"]}"
+      _create_network_service_entity(@entity, result["port"],protocol="tcp",generic_details={"extended_spyse" => result})
     end
   end
-
-  
-
 
 end
 end

--- a/lib/tasks/search_spyse.rb
+++ b/lib/tasks/search_spyse.rb
@@ -11,8 +11,8 @@ class SearchSpyse < BaseTask
       :references => ["https://spyse.com/apidocs"],
       :type => "discovery",
       :passive => true,
-      :allowed_types => ["String", "Domain"],
-      :example_entities => [{"type" => "String", "details" => {"name" => "jira"}}],
+      :allowed_types => ["IpAddress","String", "Domain"],
+      :example_entities => [{"type" => "String", "details" => {"name" => "1.1.1.1"}}],
       :allowed_options => [],
       :created_types => ["DnsRecord","IpAddress","Organization","PhysicalLocation"]
     }
@@ -28,64 +28,89 @@ class SearchSpyse < BaseTask
     # Make sure the key is set
     api_key = _get_task_config("spyse_api_key")
     # Set the headers
-    headers = {"api_token" =>  api_key}
+    headers = { "Accept" =>  "application/json" , "Authorization" => "Bearer #{api_key}" }
 
-    # Returns aggregate information by subdomain word : total count of subdomains, list of IPs of subdomains and subdomain count on every IP,
-    # list of countries and subdomain count from it, list of CIDRs /24, /16 and subdomain list on every CIDR.
-    if entity_type == "String"
-      url = "https://api.spyse.com/v1/domains-starts-with-aggregate?sdword=#{entity_name}"
-      get_subdomains entity_name, api_key, headers, url
-
-    # Returns aggregate information by domain: total count of subdomains, list of IPs of subdomains and subdomain count on every IP,
-    # list of countries and subdomain count from it, list of CIDRs /24, /16 and subdomain list on every CIDR.
-    elsif entity_type == "Domain"
-      url = "https://api.spyse.com/v1//subdomains-aggregate?domain=#{entity_name}"
-      get_subdomains entity_name, api_key, headers, url
-
+    if entity_type == "IpAddress"
+      #search Ip for reputation, Open ports, related information
+      search_ip_reputation entity_name,headers
     else
       _log_error "Unsupported entity type"
     end
 
   end #end run
 
+  #Lists open ports on IP
+  # def search_ip_port(entity_name, headers)
+  #
+  #   # Set the headers
+  #   url = "https://api.spyse.com/v2/data/ip/port?limit=100&ip=#{entity_name}"
+  #
+  #   # make the request
+  #   response = http_get_body(url,nil,headers)
+  #   json = JSON.parse(response)
+  #   #puts json
+  #   json["data"]["items"].each do |result|
+  #       puts "#{entity_name}: #{result["port"]}"
+  #     if result["service"] == ""
+  #
+  #     #_create_entity("IpAddress", {"name" => entity_name, "open_port" => result["port"] , "service" => result["service"]})
+  #       _log_good "Creating service on #{entity_name}: #{result["port"]}"
+  #       _create_network_service_entity(@entity, result["port"])
+  #     else
+  #       _log_good "Creating service on #{entity_name}: #{result["port"]}"
+  #       _create_network_service_entity(@entity, result["port"],result["service"])
+  #     end
+  #   end
+  # end
 
-  # Returns aggregate information by subdomain word and domain
-  def get_subdomains entity_name, api_key, headers, url
+  #search IP
+  def search_ip_reputation(entity_name, headers)
 
+    # Set the headers
+    url = "https://api.spyse.com/v2/data/ip?limit=100&ip=#{entity_name}"
+
+    # make the request
     response = http_get_body(url,nil,headers)
     json = JSON.parse(response)
+    #puts json
+    json["data"]["items"].each do |result|
+      # #create physical location
+      # if result["maxmind_geo"]["country"]
+        # puts result["maxmind_geo"]["country"]
+         #_create_entity("PhysicalLocation", "name" => result["maxmind_geo"]["country"])
+      # end
+      # # Create list of related organizations
+      # if result["maxmind_isp"]["org"]
+         #puts result["maxmind_isp"]["org"]
+         #_create_entity("Organization", "name" => result["entity"]["organization"])
+      # end
 
-    #check if entries different to null
-    if json["count"] != 0
-      # Create subdomains
-      json["cidr"]["cidr16"]["results"].each do |e|
-        e["data"]["domains"].each do |s|
-          _create_entity("DnsRecord", "name" => s)
-        end
-      end
-     # Create subdomains
-      json["cidr"]["cidr24"]["results"].each do |e|
-        e["data"]["domains"].each do |s|
-          _create_entity("DnsRecord", "name" => s)
-        end
-      end
-
-      # Create list of related organizations
-      json["data"]["as"]["results"].each do |e|
-        _create_entity("Organization", "name" => e["entity"]["organization"])
-      end
-
-      # Create list of related countrys
-      json["data"]["country"]["results"].each do |e|
-        _create_entity("PhysicalLocation", "name" => e["entity"]["value"])
-      end
-
-      # Create list of related IPs
-      json["data"]["ip"]["results"].each do |e|
-        _create_entity("IpAddress", "name" => e["entity"]["value"])
+      if result["score"] < 100
+        _create_linked_issue("suspicious_activity_detected",{
+          severity: result["score"],
+          references: ["https://spyse.com/"],
+          source:"Spyse",
+          details: result
+        })
       end
     end
-  end #end subdomain
+    # Search for open ports
+    url2 = "https://api.spyse.com/v2/data/ip/port?limit=100&ip=#{entity_name}"
+
+    # make the request
+    response2 = http_get_body(url2,nil,headers)
+    json2 = JSON.parse(response2)
+    #puts json
+    json2["data"]["items"].each do |result|
+        puts "#{entity_name}:#{result["port"]}"
+      #_create_entity("IpAddress", {"name" => entity_name, "open_port" => result["port"] , "service" => result["service"]})
+        _log_good "Creating service on #{entity_name}: #{result["port"]}"
+        _create_network_service_entity(@entity, result["port"])
+    end
+  end
+
+  
+
 
 end
 end

--- a/lib/tasks/search_spyse_cert.rb
+++ b/lib/tasks/search_spyse_cert.rb
@@ -1,0 +1,82 @@
+module Intrigue
+module Task
+class SearchSpyseCert < BaseTask
+
+  def self.metadata
+    {
+      :name => "search_spyse_cert",
+      :pretty_name => "Search Spyse Cert",
+      :authors => ["Anas Ben Salah"],
+      :description => "This task hits Spyse API for discovring domains registered with the same certificate",
+      :references => ["https://spyse.com/apidocs"],
+      :type => "discovery",
+      :passive => true,
+      :allowed_types => ["SslCertificate"],
+      :example_entities => [{"type" => "String", "details" => {"name" => "intrigue.io"}}],
+      :allowed_options => [],
+      :created_types => ["DnsRecord","Organization","PhysicalLocation"]
+    }
+  end
+
+  ## Default method, subclasses must override this
+  def run
+    super
+
+    entity_name = _get_entity_name
+    entity_type = _get_entity_type_string
+
+    # Make sure the key is set
+    api_key = _get_task_config("spyse_api_key")
+    # Set the headers
+    headers = { "Accept" =>  "application/json" , "Authorization" => "Bearer #{api_key}" }
+
+    if entity_type == "SslCertificate"
+      #search Ip for reputation, Open ports, related information
+      search_domain_registered_with_same_cert entity_name,headers
+    else
+      _log_error "Unsupported entity type"
+    end
+
+  end #end run
+
+  # search for domains registred with same certificate
+  def search_domain_registered_with_same_cert(entity_name, headers)
+
+    # Set the headers
+    url = "https://api.spyse.com/v2/data/cert?limit=100&hash=#{entity_name}"
+
+    # make the request
+    response = http_get_body(url,nil,headers)
+    json = JSON.parse(response)
+    #puts json
+
+    #create an issue if many domains founded registered with same Certificate
+    json["data"]["items"].each do |result|
+      if result["parsed"]["names"]
+        _create_linked_issue("domains_registered_with_same_certificate",{
+          references: ["https://spyse.com/"],
+          source:"Spyse",
+          details: result["parsed"]
+        })
+      end
+
+      #create DnsRecord from domains registered with same certificate
+      if result["parsed"]["names"]
+        result["parsed"]["names"].each do |domain|
+          _create_entity("DnsRecord", {"name" => domain })
+        end
+      end
+
+      #create organizations related to the certificate
+      if result["parsed"]["subject"]["organization"]
+        result["parsed"]["subject"]["organization"].each do |organization|
+          _create_entity("Organization", {"name" => organization })
+        end
+      end
+      
+    end
+  end #end search_domain_registered_with_same_cert
+
+end
+end
+end

--- a/lib/tasks/search_spyse_domain.rb
+++ b/lib/tasks/search_spyse_domain.rb
@@ -1,0 +1,118 @@
+module Intrigue
+module Task
+class SearchSpyseDomain < BaseTask
+
+  def self.metadata
+    {
+      :name => "search_spyse_domain",
+      :pretty_name => "Search Spyse Domain",
+      :authors => ["Anas Ben Salah"],
+      :description => "This task hits Spyse API for  domains registered with the same IP and related subdomains",
+      :references => ["https://spyse.com/apidocs"],
+      :type => "discovery",
+      :passive => true,
+      :allowed_types => ["Domain"],
+      :example_entities => [{"type" => "Domain", "details" => {"name" => "intrigue.io"}}],
+      :allowed_options => [],
+      :created_types => ["DnsRecord","IpAddress","Organization","PhysicalLocation"]
+    }
+  end
+
+  ## Default method, subclasses must override this
+  def run
+    super
+
+    entity_name = _get_entity_name
+    entity_type = _get_entity_type_string
+
+    # Make sure the key is set
+    api_key = _get_task_config("spyse_api_key")
+    # Set the headers
+    headers = { "Accept" =>  "application/json" , "Authorization" => "Bearer #{api_key}" }
+
+    if entity_type == "Domain"
+      # Search Ip for domain hosted on the same IP
+      search_domain_on_same_ip entity_name,headers
+
+      # Search subdomain related to the domain 
+      search_subdomains entity_name,headers
+    else
+      _log_error "Unsupported entity type"
+    end
+
+  end #end
+
+  # Search IP reputation and gathering data
+  def search_domain_on_same_ip(entity_name, headers)
+
+    # Set the URL for ip data
+    url = "https://api.spyse.com/v2/data/domain/on_same_ip?limit=100&domain=#{entity_name}"
+
+    # make the request
+    response = http_get_body(url,nil,headers)
+    json = JSON.parse(response)
+
+    json["data"]["items"].each do |result|
+
+      # Create Dnsrecords shared the same ip
+      if result["name"]
+        _create_entity("DnsRecord", "name" => result["name"], "extended_spyse" => result)
+      end
+
+      # Create SslCertificate
+      if result["cert_summary"]["fingerprint_sha256"]
+        _create_entity("SslCertificate", "name" => result["cert_summary"]["fingerprint_sha256"], "extended_spyse" => result["cert_summary"])
+      end
+
+      # Create related IpAddress, physical location and ISP organization
+      if result["dns_records"]
+        result["dns_records"]["A"].each do |ip_result|
+          _create_entity("IpAddress", "name" => ip_result["ip"], "extended_spyse" => ip_result)
+          _create_entity("PhysicalLocation", "name" => ip_result["country"])
+          _create_entity("Organization", "name" => ip_result["org"])
+        end
+      end
+
+    end
+  end
+
+  # Search for open ports
+  def search_subdomains entity_name, headers
+
+    # Set the URL for ip open ports
+    url2 = "https://api.spyse.com/v2/data/domain/subdomain?limit=100&domain=#{entity_name}"
+
+    # make the request
+    response2 = http_get_body(url2,nil,headers)
+    json2 = JSON.parse(response2)
+
+    json2["data"]["items"].each do |result|
+
+      # Create related subdomains
+      _create_entity("DnsRecord", "name" => result["name"], "extended_spyse" => result)
+
+      # Create SslCertificate
+      if result["cert_summary"]["fingerprint_sha256"] != ""
+        _create_entity("SslCertificate", "name" => result["cert_summary"]["fingerprint_sha256"], "extended_spyse" => result["cert_summary"])
+      end
+      # Create related IpAddress, physical location and ISP organization
+      # if result["dns_records"]
+      #   result["dns_records"]["A"].each do |ip_result|
+      #     if ip_result["ip"] != ""
+      #       _create_entity("IpAddress", "name" => ip_result["ip"], "extended_spyse" => ip_result)
+      #     end
+      #     if ip_result["country"] != ""
+      #       _create_entity("PhysicalLocation", "name" => ip_result["country"])
+      #     end
+      #     if ip_result["org"] != ""
+      #       _create_entity("Organization", "name" => ip_result["org"])
+      #     end
+      #   end
+      #  end
+
+    end
+  end
+
+end
+end
+end

--- a/lib/tasks/search_spyse_domain.rb
+++ b/lib/tasks/search_spyse_domain.rb
@@ -34,7 +34,7 @@ class SearchSpyseDomain < BaseTask
       # Search Ip for domain hosted on the same IP
       search_domain_on_same_ip entity_name,headers
 
-      # Search subdomain related to the domain 
+      # Search subdomain related to the domain
       search_subdomains entity_name,headers
     else
       _log_error "Unsupported entity type"
@@ -46,7 +46,7 @@ class SearchSpyseDomain < BaseTask
   def search_domain_on_same_ip(entity_name, headers)
 
     # Set the URL for ip data
-    url = "https://api.spyse.com/v2/data/domain/on_same_ip?limit=100&domain=#{entity_name}"
+    url = "https://api.spyse.com/v3/data/domain/on_same_ip?limit=100&domain=#{entity_name}"
 
     # make the request
     response = http_get_body(url,nil,headers)
@@ -80,7 +80,7 @@ class SearchSpyseDomain < BaseTask
   def search_subdomains entity_name, headers
 
     # Set the URL for ip open ports
-    url2 = "https://api.spyse.com/v2/data/domain/subdomain?limit=100&domain=#{entity_name}"
+    url2 = "https://api.spyse.com/v3/data/domain/subdomain?limit=100&domain=#{entity_name}"
 
     # make the request
     response2 = http_get_body(url2,nil,headers)

--- a/lib/tasks/threat/search_dshield.rb
+++ b/lib/tasks/threat/search_dshield.rb
@@ -1,0 +1,54 @@
+module Intrigue
+module Task
+class SearchDshield < BaseTask
+
+
+  def self.metadata
+    {
+      :name => "threat/search_dshield",
+      :pretty_name => "Threat Check - Search Dshield",
+      :authors => ["Anas Ben Salah"],
+      :description => "This task hits Dshield api for Ip reputation and threat feeds ",
+      :references => ["https://www.dshield.org/api/#ip"],
+      :type => "threat_check",
+      :passive => true,
+      :allowed_types => ["IpAddress"],
+      :example_entities => [{"type" => "IpAddress", "details" => {"name" => "1.1.1.1"}}],
+      :allowed_options => [],
+      :created_types => []
+    }
+  end
+
+
+  ## Default method, subclasses must override this
+  def run
+    super
+
+      #get entity name and type
+      entity_name = _get_entity_name
+
+      #headers
+      headers = { "Accept" =>  "application/json"}
+
+      # Get responce
+      response = http_get_body("https://www.dshield.org/api/ip/#{entity_name}?json",nil,headers)
+      result = JSON.parse(response)
+
+      if result["attacks"] != "null" or result["maxrisk"] != "null"
+        _create_linked_issue("suspicious_activity_detected", {
+          status: "confirmed",
+          description: "This ip was flagged by Dshield for malicious activites",
+          fraudguard_details: result,
+          source: "Dshield.org"
+        })
+        # Also store it on the entity
+        blocked_list = @entity.get_detail("suspicious_activity_detected") || []
+        @entity.set_detail("suspicious_activity_detected", blocked_list.concat([{}]))
+    end
+  end #end run
+
+
+
+end
+end
+end

--- a/lib/tasks/threat/search_ipqs.rb
+++ b/lib/tasks/threat/search_ipqs.rb
@@ -1,0 +1,71 @@
+module Intrigue
+module Task
+class SearchIPQS < BaseTask
+
+
+  def self.metadata
+    {
+      :name => "threat/search_IPQualityScore",
+      :pretty_name => "Threat Check - Search IPQualityScore",
+      :authors => ["Anas Ben Salah"],
+      :description => "This task hits IPQualityScore.com api for IP reputation and nature",
+      :references => ["https://www.ipqualityscore.com/documentation/proxy-detection/overview"],
+      :type => "threat_check",
+      :passive => true,
+      :allowed_types => ["IpAddress"],
+      :example_entities => [{"type" => "IpAddress", "details" => {"name" => "1.1.1.1"}}],
+      :allowed_options => [],
+      :created_types => ["Organization","PhysicalLocation"]
+    }
+  end
+
+
+  ## Default method, subclasses must override this
+  def run
+    super
+
+      #get entity name and type
+      entity_name = _get_entity_name
+
+      #get keys for API authorization
+      password =_get_task_config("ipqs_api_key")
+
+      headers = { "Accept" =>  "application/json"}
+
+      unless password
+        _log_error "unable to proceed, no API key for IpQualityScore provided"
+        return
+      end
+
+      # Get responce
+      response = http_get_body("https://www.ipqualityscore.com/api/json/ip/#{password}/#{entity_name}?strictness=0&allow_public_access_points=true&fast=true&lighter_penalties=true&mobile=true",nil, headers)
+      result = JSON.parse(response)
+      #puts result
+
+      #Create organization entity
+      if response["organization"]
+        _create_entity("Organization", {"name" => response["organization"]})
+      end
+
+      #Create PhysicalLocation entity
+      if response["region"]
+        _create_entity("PhysicalLocation", {"name" => response["region"]})
+      end
+
+      #create an issue if this IP related to fraud
+      if result["success"] and result["fraud_score"] > 0
+        _create_linked_issue("suspicious_activity_detected", {
+          status: "confirmed",
+          description: "This ip was flagged by IPQualtiyScore for fraud activites",
+          IpQulaityScore_details: result,
+          source: "IpQualityScore.com"
+        })
+
+    end
+  end #end run
+
+
+
+end
+end
+end

--- a/lib/tasks/threat/search_ipqs_emailaddress.rb
+++ b/lib/tasks/threat/search_ipqs_emailaddress.rb
@@ -1,0 +1,63 @@
+module Intrigue
+module Task
+class SearchIPQSEmailAddress < BaseTask
+
+
+  def self.metadata
+    {
+      :name => "search_IPQualityScore_EmailAddress",
+      :pretty_name => "Search IPQualityScore EmailAddress",
+      :authors => ["Anas Ben Salah"],
+      :description => "This task hits IPQualityScore.com api for EmailAddress validation ",
+      :references => ["https://www.ipqualityscore.com/documentation/email-validation/overview"],
+      :type => "discovery",
+      :passive => true,
+      :allowed_types => ["EmailAddress"],
+      :example_entities => [{"type" => "EmailAddress", "details" => {"name" => "test@gmail.com"}}],
+      :allowed_options => [],
+      :created_types => ["EmailAddress"]
+    }
+  end
+
+
+  ## Default method, subclasses must override this
+  def run
+    super
+      #get entity name and type
+      entity_name = _get_entity_name
+
+      #get keys for API authorization
+      password =_get_task_config("ipqs_api_key")
+
+      headers = { "Accept" =>  "application/json"}
+
+      unless password
+        _log_error "unable to proceed, no API key for IpQualityScore provided"
+        return
+      end
+
+      # Get responce
+      response = http_get_body("https://www.ipqualityscore.com/api/json/email/#{password}/#{entity_name}",nil, headers)
+      result = JSON.parse(response)
+      #puts result
+
+      #Create organization entity
+      if result["success"] == true
+        _create_entity("EmailAddress", {"name" => result["sanitized_email"]})
+        _set_entity_detail("extended_ipqualityscore",result)
+      end
+
+      #create an issue if this IP related to fraud
+      if result["leaked"]== true or result["suspect"] == true or result["spam_trap_score"] != "none"
+        _create_linked_issue("suspicious_activity_detected", {
+          status: "confirmed",
+          description: "This Email Address was flagged by IPQualtiyScore for these reasons: Leak:#{result["leaked"]} // suspicious activity:#{result["suspect"]} // Spam:#{result["spam_trap_score"]} ",
+          IpQualityScore_details: result,
+          source: "IpQualityScore.com"
+        })
+      end
+  end #end run
+
+end
+end
+end


### PR DESCRIPTION
Spyse holds one of the largest database containing a wide range of OSINT data handy for reconnaissance. This task hits spyse.com API for discovering domains registered on the same IP also listing all its subdomains. This task provides with different fields like:

> name
> ingerprint_sha256
> issuer_dn
> subject_dn
> tls_version
> dns_records
> is_MX
> is_NS
> extract
> whois_parsed
> emails
> external_redirect_uri
> http_headers
> http_status_code
> meta_tags
> scripts
> title

Demo: 
[screenshot: general results] 
![image](https://user-images.githubusercontent.com/35723779/84554710-12d1a580-ad11-11ea-9cce-5ea539a27609.png)