### PR TITLE
Send to local elasticsearch

### DIFF
--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -37,13 +37,14 @@ module Intrigue
         where(Sequel.&(project_id: named_project.id, type: resolved_entity_type.to_s)) if named_project
       end
 
-      #def self.scope_by_project_and_type_and_detail_value(project_name, entity_type, detail_name, detail_value)
-      #  json_details = Sequel.pg_jsonb_op(:details)
-      #  candidate_entities = scope_by_project_and_type(project_name,entity_type)
-      #  our_value = json_details.get_text(detail_name)
-      #  candidate_entities.where(our_value => detail_value)
-      #end
-      
+      def uuid
+        project_name = self.project.name if self.project
+        project_name = "missing_project" unless project_name
+
+        out = "#{project_name}##{self.type}##{self.name}"
+        Digest::SHA2.hexdigest(out)
+      end
+
       def ancestors
         ancestors = []
         task_results.each do |tr|

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -20,6 +20,19 @@ module Intrigue
         validates_unique([:entity_id, :name, :project_id, :source], allow_nil: true)
       end
 
+      def uuid
+        project_name = self.project.name if self.project
+        project_name = "missing_project" unless project_name
+
+        source = source if source
+        source = 'intrigue' unless source
+
+        out = "#{project_name}##{self.name}#{source}##{entity.uuid}"
+        
+        Digest::SHA2.hexdigest(out)
+      end
+
+
       def to_s
         "#{name} on #{entity.type} #{entity.name}"
       end

--- a/config/config.json.default
+++ b/config/config.json.default
@@ -50,6 +50,10 @@
       "aws_s3_bucket": "",
       "uri": ""
     },
+    "send_to_elasticsearch": {
+      "endpoint" : "http://localhost",
+      "port" : 9200
+    },
     "send_to_webhook": {
       "uri": "http://127.0.0.1:9999/"
     }

--- a/lib/all.rb
+++ b/lib/all.rb
@@ -67,6 +67,12 @@ Dir["#{issues_folder}/*.rb"].each {|f| require_relative f}
 ####
 # Handler Libraries
 ####
+
+# require handler-specifics here
+require 'faraday_middleware'
+require 'elasticsearch'
+
+###
 require_relative 'handler_factory'
 require_relative 'handlers/base'
 handlers_folder = File.expand_path('../handlers', __FILE__) # get absolute directory


### PR DESCRIPTION
This PR adds a handler to send to a local elasticsearch instance, per the request in #155. Note that credentials are not used, so at the moment it requires you to be running an unauthenticated local installation. The hostname and port are configurable through the normal method (editing the relevant fields in config/config.json) or hitting System -> Handler config and configuring the relevant fields. 