### PR TITLE
Add checks for hadoop, jenkins, jupyter from new Google Tsunami scanner

### DIFF
--- a/lib/issues/hadoop_yarn_resourcemanager_api_access.rb
+++ b/lib/issues/hadoop_yarn_resourcemanager_api_access.rb
@@ -1,0 +1,29 @@
+module Intrigue
+  module Issue
+  class HadoopYarnResourcemanagerApiAccess < BaseIssue
+  
+    def self.generate(instance_details={})
+      {
+        name: "hadoop_yarn_resourcemanager_api_access",
+        pretty_name: "Hadoop YARN ResourceManager API Access",
+        severity: 1,
+        category: "application",
+        status: "confirmed",
+        description: "Hadoop Yarn ResourceManager controls the computation and storage resources of" + 
+                     " a Hadoop cluster. Unauthenticated ResourceManager API allows any" + 
+                     " remote users to create and execute arbitrary applications on the" + 
+                     " host.",
+        remediation: "Investigate the page and ensure all resources are loaded over HTTPS.",
+        affected_software: [
+          { :vendor => "Hadoop", :product => "YARN" }
+        ],
+        references: [ # types: description, remediation, detection_rule, exploit, threat_intel
+          { type: "description", uri: "https://github.com/google/tsunami-security-scanner-plugins/blob/master/google/detectors/exposedui/hadoop/yarn/src/main/java/com/google/tsunami/plugins/detectors/exposedui/hadoop/yarn/YarnExposedManagerApiDetector.java" }
+        ]
+      }.merge!(instance_details)
+    end
+  
+  end
+  end
+  end
+  

--- a/lib/issues/juypter_exposed_ui_detection.rb
+++ b/lib/issues/juypter_exposed_ui_detection.rb
@@ -1,0 +1,26 @@
+module Intrigue
+  module Issue
+  class JupyterExposedUiDetection < BaseIssue
+  
+    def self.generate(instance_details={})
+      {
+        name: "jupyter_exposed_ui_detection",
+        pretty_name: "Jupyter Exposed UI Detection",
+        severity: 4,
+        category: "application",
+        status: "confirmed",
+        description:  "This detector checks whether a unauthenticated Jupyter Notebook is exposed. Jupyter" + 
+                      " allows by design to run arbitrary code on the host machine. Having it exposed puts" + 
+                      " the hosting VM at risk of RCE.",
+        remediation: "Put the Jupyter notebook behind authentication.",
+        affected_software: [ { :vendor => "Jupyter", :product => "Notebook" } ],
+        references: [ # types: description, remediation, detection_rule, exploit, threat_intel
+          { type: "description", uri: "https://jupyter-notebook.readthedocs.io/en/stable/security.html" },
+          { type: "source", uri: "https://github.com/google/tsunami-security-scanner-plugins/blob/master/google/detectors/exposedui/jupyter/src/main/java/com/google/tsunami/plugins/detectors/exposedui/jupyter/JupyterExposedUiDetector.java"}
+        ]
+      }.merge!(instance_details)
+    end
+  
+  end
+  end
+  end

--- a/lib/issues/unauthenticated_jenkins_create_projects.rb
+++ b/lib/issues/unauthenticated_jenkins_create_projects.rb
@@ -1,0 +1,26 @@
+module Intrigue
+  module Issue
+  class UnauthenticatedJenkinsCreateProjects < BaseIssue
+  
+    def self.generate(instance_details={})
+      to_return = {
+        name: "unauthenticated_jenkins_create_projects",
+        pretty_name: "Unauthenicated Users can create Projects in Jenkins",
+        severity: 1,
+        references: [
+          "https://github.com/google/tsunami-security-scanner-plugins/blob/master/google/detectors/exposedui/jenkins/src/main/java/com/google/tsunami/plugins/detectors/exposedui/jenkins/JenkinsExposedUiDetector.java"
+        ],
+        category: "application",
+        status: "confirmed",
+        description:  "Unauthenticated Jenkins instance allows anonymous users to create arbitrary" +
+                      " projects, which usually leads to code downloading from the internet" +
+                      " and remote code executions."
+      }.merge!(instance_details)
+  
+    to_return
+    end
+  
+  end
+  end
+  end
+  

--- a/lib/issues/vulnerability_webmin_cve_2019_15107.rb
+++ b/lib/issues/vulnerability_webmin_cve_2019_15107.rb
@@ -1,0 +1,32 @@
+module Intrigue
+  module Issue
+  class VulnerableWebminInstall < BaseIssue
+  
+    def self.generate(instance_details={})
+      {
+        name: "vulnerability_webmin_cve_2019_15107",
+        pretty_name: "Vulnerable Webmin Password Reset (CVE-2019-15107)",
+        identifiers: [
+          { type: "CVE", name: "CVE-2019-15107" }
+        ],
+        severity: 1,
+        status: "potential",
+        category: "vulnerability",
+        description: "The vulnerability was secretly planted by an unknown hacker who successfully managed to inject a BACKDOOR at some point in its build infrastructure that surprisingly persisted into various releases of Webmin (1.882 through 1.921) and eventually remained hidden for over a year.",
+        remediation: "Update the webmin installation",
+        affected_software: [
+          { :vendor => "Webmin", :product => "Webmin"},
+        ],
+        references: [
+          { type: "description", uri: "https://pentest.com.tr/exploits/DEFCON-Webmin-1920-Unauthenticated-Remote-Command-Execution.html" } , 
+        ],
+      }.merge!(instance_details)
+    end
+  
+  end
+  end
+  end
+  
+  
+          
+  

--- a/lib/tasks/uri_brute_focused_content.rb
+++ b/lib/tasks/uri_brute_focused_content.rb
@@ -42,7 +42,12 @@ class UriBruteFocusedContent < BaseTask
     # we need a FP here, so hold off until 
     require_enrichment unless override.length > 0
 
-    fingerprint = _get_entity_detail("fingerprint")
+    if override
+      _log "SEtting Override to #{override}"
+      fingerprint = [{"product" => override }]
+    else 
+      fingerprint = _get_entity_detail("fingerprint")
+    end
 
     generic_list = [ 
       #{ path: "/api", body_regex: nil },
@@ -140,7 +145,8 @@ class UriBruteFocusedContent < BaseTask
       { issue_type: "jenkins_exposed_path", path: "/systemInfo",  severity: 4, body_regex: /Jenkins/i, status: "confirmed" },
       { issue_type: "jenkins_exposed_path", path: "/script",  severity: 4, body_regex: /Jenkins/i, status: "confirmed" },
       { issue_type: "jenkins_exposed_path", path: "/signup",  severity: 5, body_regex: /Jenkins/i, status: "confirmed" },
-      { issue_type: "jenkins_exposed_path", path: "/securityRealm/createAccount", severity: 4, body_regex: /Jenkins/i , status: "confirmed"}
+      { issue_type: "jenkins_exposed_path", path: "/securityRealm/createAccount", severity: 4, body_regex: /Jenkins/i , status: "confirmed"},
+      { issue_type: "unauthenticated_jenkins_create_projects", path: "/view/all/newJob", severity: 1, body_regex: /form#createItem/i , status: "confirmed"}
     ]
 
     jforum_list = [ # CVE-2019-7550
@@ -154,9 +160,14 @@ class UriBruteFocusedContent < BaseTask
       { issue_type: "jira_2fa_bypass", path: "/login.action?nosso", severity: 3,
         body_regex: //i, status: "confirmed" } 
     ]
+
     # 
     joomla_list = [   # https://packetstormsecurity.com/files/151619/Joomla-Agora-4.10-Bypass-SQL-Injection.html
       { issue_type: "vulnerable_joomla", path: "/index.php?option=com_agora&task='", severity: 2, status: "potential" } 
+    ] 
+
+    jupyter_notebook_list = [ 
+      { issue_type: "jupyter_exposed_ui_detection", path: "/terminals/1", severity: 1, body_regex: /terminals\/websocket\/1/i, status: "confirmed" } 
     ] 
 
     lotus_domino_list = [
@@ -315,6 +326,7 @@ class UriBruteFocusedContent < BaseTask
     jforum_list.each { |x| work_q.push x } if is_product?(fingerprint,"Jforum")
     jira_list.each { |x| work_q.push x } if is_product?(fingerprint,"Jira")
     joomla_list.each { |x| work_q.push x } if is_product?(fingerprint,"Joomla!")
+    jupyter_notebook_list.each { |x| work_q.push x } if is_product?(fingerprint,"Notebook")
     lotus_domino_list.each { |x| work_q.push x } if is_product?(fingerprint,"Domino")
     php_list.each { |x| work_q.push x } if is_product?(fingerprint,"PHP")
     php_my_admin_list.each { |x| work_q.push x } if is_product?(fingerprint,"phpMyAdmin")

--- a/lib/tasks/uri_check_api_endpoint.rb
+++ b/lib/tasks/uri_check_api_endpoint.rb
@@ -37,10 +37,11 @@ class UriCheckApiEndpoint < BaseTask
     api_endpoint = true if url =~ /\/api/
     api_endpoint = true if url =~ /\/json/
     api_endpoint = true if url =~ /\.json/
+    api_endpoint = true if url =~ /\.xml/
 
     # check for content type of applciation.. note that this will flag
     # application/javascript, which is probably not wanted
-    headers = _get_entity_detail("headers")
+    headers = _get_entity_detail("headers") || []
     if headers
       content_type_header = headers.select{|x| x =~ /content-type/i }
       
@@ -50,7 +51,7 @@ class UriCheckApiEndpoint < BaseTask
     end
     
     # check fingerprints8
-    fingerprint = _get_entity_detail("fingerprint")
+    fingerprint = _get_entity_detail("fingerprint") || []
     fingerprint.each do |fp|
       api_endpoint = true if fp["tags"] && fp["tags"].include?("API")
     end 
@@ -59,9 +60,12 @@ class UriCheckApiEndpoint < BaseTask
     begin
       # get request body
       body = _get_entity_detail("extended_response_body")
-      json = JSON.parse(body)
-      api_endpoint = true if json
+      if body 
+        json = JSON.parse(body)
+        api_endpoint = true if json
+      end
     rescue JSON::ParserError      
+      _log "No body"
     end
 
     # set the details 

--- a/lib/tasks/uri_create_browser_requested_endpoints.rb
+++ b/lib/tasks/uri_create_browser_requested_endpoints.rb
@@ -44,7 +44,7 @@ class UriCreateBrowserRequestedEndpoints < BaseTask
       if browser_responses = _get_entity_detail("extended_browser_wsresponses")
         browser_responses.each do |r|
           next unless "#{r["uri"]}" =~ /^http/i
-          _create_entity("Uri", {"name" => r["url"] })
+          _create_entity("Uri", {"name" => r["url"], "api_endpoint" => true })
         end
       else 
         _log_error "Unable to create entities, missing 'extended_responses' detail"

--- a/lib/tasks/vulns/hadoop_yarn_unathenticated_resourcemanager.rb
+++ b/lib/tasks/vulns/hadoop_yarn_unathenticated_resourcemanager.rb
@@ -1,0 +1,59 @@
+###
+### Task is in good shape, just needs some option parsing, and needs to deal with paths
+###
+module Intrigue
+  module Task
+  class  HadoopYarnCheck < BaseTask
+  
+    def self.metadata
+      {
+        :name => "vuln/hadoop_yarn_unauthenticated_check",
+        :pretty_name => "Vuln Check - Hadoop YARN unauthenicated check",
+        :authors => ["jcran"],
+        :identifiers => [],
+        :description => "CHecks for unauthenticated resource manager access.",
+        :references => [
+          "https://github.com/google/tsunami-security-scanner-plugins/blob/11f0eb11b31a8f08e03090dbed2e89884c7fa279/google/detectors/exposedui/hadoop/yarn/src/main/java/com/google/tsunami/plugins/detectors/exposedui/hadoop/yarn/YarnExposedManagerApiDetector.java#L142"
+        ],
+        :type => "vuln_check",
+        :passive => false,
+        :allowed_types => ["Uri"],
+        :example_entities => [{"type" => "Uri", "details" => {"name" => "https://intrigue.io"}}],
+        :allowed_options => [],
+        :created_types => []
+      }
+    end
+  
+    ## Default method, subclasses must override this
+    def run
+      super
+      
+      uri = _get_entity_name
+
+      # pull off last '/' if it exists 
+      if uri[-1] == "/"
+        uri = uri[0..-2]
+      end
+
+      # post to endpoint with nothing
+      response = http_request(:post, "#{uri}/ws/v1/cluster/apps/new-application")
+
+      _log "Got response: #{response.body}"
+      if response.body == /WebApplicationException/
+        _log "Vulnerable? Got exception"
+        _create_linked_issue "hadoop_yarn_resourcemanager_api_access", {"proof": response.body}
+      elsif response.body == /application-id/
+        json = JSON.parse(response.body)
+        _log "Vulnerable! Created app: #{json["applicationid"]}"
+        _create_linked_issue "hadoop_yarn_resourcemanager_api_access", {"proof": response.body}
+      else 
+        _log "Unknown response: #{response.body}"
+      end
+  
+    end
+  
+   
+  end
+  end
+  end
+  

--- a/lib/tasks/vulns/webmin_pwreset_cve_2019_15107.rb
+++ b/lib/tasks/vulns/webmin_pwreset_cve_2019_15107.rb
@@ -7,11 +7,11 @@ class  WebminPwreset < BaseTask
 
   def self.metadata
     {
-      :name => "vuln/webmin_pwreset",
+      :name => "vuln/webmin_pwreset_cve_2019_15107",
       :pretty_name => "Vuln Check - Webmin Password Reset Check",
       :authors => ["jcran","AkkuS <Özkan Mustafa Akkuş>"],
       :identifiers => [{ "cve" =>  "CVE-2019-15107" }],
-      :description => "Check for a webmine unauthenticated RCE. Requires a specific configuration, see references.",
+      :description => "Check for a webmin unauthenticated RCE. Requires a specific configuration, see references.",
       :references => [
         "https://pentest.com.tr/exploits/DEFCON-Webmin-1920-Unauthenticated-Remote-Command-Execution.html"
       ],
@@ -46,15 +46,13 @@ class  WebminPwreset < BaseTask
       return
     end
 
-    _create_issue({
-        name: "Vulnerable Webmin Install",
-        severity: 1,
-        type: "vulnerability_webmin_cve_2019_15107",
-        status: "potential",
-        description: "This server found at #{_get_entity_name} is vulnerable to an unauthenticated admin password reset.",
-        references: self.class.metadata["references"]
-      })
+    
 
+    ###
+    ### TODO ... needs to verify, this has been fixed.
+    ###
+    # Create as potential
+    _create_linked_issue( "vulnerability_webmin_cve_2019_15107") 
 
     # if we made it this far, try to reset
     #headers = { 'Cookie' => "redirect=1; testing=1; sid=x; sessiontest=1",


### PR DESCRIPTION
Google Tsunami is a new Devops focused scanner written in Java and released with four checks - three of which were not definitely yet in Intrigue Core. While primarily focused on Devops / build pipe scanning (i believe), they were reasonable to add to our check list. This PR adds the checks for Jupyter, Jenkins and Hadoop. The fourth is a check for an exposed Wordpress instance which may be added at a later date. 

Thank you to the Google team and congrats on the release!