### PR TITLE
Add task for @erbbysam's parsed-tls-hostnames endpoint

### DIFF
--- a/lib/tasks/dns_search_sonar.rb
+++ b/lib/tasks/dns_search_sonar.rb
@@ -12,7 +12,7 @@ class DnsSearchSonar < BaseTask
       :description => "Search Rapid7's Project Sonar for FDNS and RDNS records matching a given pattern. Utilizes @erbbysam's excellent DNSGrep server to serve results.",
       :references => [],
       :type => "discovery",
-      :passive => false,
+      :passive => true,
       :allowed_types => ["DnsRecord","Domain"],
       :example_entities => [{"type" => "DnsRecord", "details" => {"name" => "intrigue.io"}}],
       :allowed_options => [
@@ -44,7 +44,7 @@ class DnsSearchSonar < BaseTask
         json["FDNS_A"].each do |entry|
           # format: "199.34.228.55,red-buddha-american-apparel-llc.company.com",
           next if entry.split(",").last =~ /mail\.mail/
-          _create_entity "DnsRecord", "name" => entry.split(",").last
+          create_dns_entity_from_string(entry.split(",").last)
         end
       end
 
@@ -52,7 +52,7 @@ class DnsSearchSonar < BaseTask
       if json["RDNS"]
         json["RDNS"].each do |entry|
           # format: "199.34.228.55,red-buddha-american-apparel-llc.company.com",
-          _create_entity "DnsRecord", "name" => entry.split(",").last
+          create_dns_entity_from_string(entry.split(",").last)
         end
       end
 

--- a/lib/tasks/dns_search_tls_cert_names.rb
+++ b/lib/tasks/dns_search_tls_cert_names.rb
@@ -1,0 +1,60 @@
+module Intrigue
+  module Task
+  class DnsSearchTlsCertnames < BaseTask
+  
+    include Intrigue::Task::Web
+  
+    def self.metadata
+      {
+        :name => "dns_search_tls_cert_names",
+        :pretty_name => "DNS Search TLS Cert Names",
+        :authors => ["jcran", "erbbysam"],
+        :description => "Search @erbbysam's TLS Cert repository (gathered from connecting for matches.",
+        :references => ["https://cdn.shopify.com/s/files/1/0177/9886/files/phv2019-serb.pdf"],
+        :type => "discovery",
+        :passive => true,
+        :allowed_types => ["DnsRecord", "Domain"],
+        :example_entities => [{"type" => "domain", "details" => {"name" => "acme.com"}}],
+        :allowed_options => [
+          {:name => "endpoint", :regex => "alpha_numeric_list", :default => "https://tls.bufferover.run/dns?q=" },
+        ],
+        :created_types => ["DnsRecord"]
+      }
+    end
+  
+    def run
+      super
+  
+      endpoint = _get_option("endpoint")
+      domain_name = ".#{_get_entity_name}"
+      search_url = "#{endpoint}#{domain_name}"
+      _log_good "Searching data for: #{domain_name}"
+      
+      response = http_request(:get, search_url, nil, {}, nil, 3, 60, 60)
+      unless response
+        _log_error "Unable to get a response. Is the server up?"
+        return false
+      end
+  
+      begin
+        json = JSON.parse(response.body)
+  
+        # Create forward dns entries
+        if json["Results"]
+          json["Results"].each do |entry|
+            # format: "54.201.204.183,,blog.erbbysam.com"
+            hostname = entry.split(",").last
+            create_dns_entity_from_string(hostname)
+          end
+        end
+  
+      rescue JSON::ParserError => e
+        _log_error "Unable to parse"
+      end
+  
+    end
+  
+  end
+  end
+  end
+  

--- a/lib/tasks/helpers/dns.rb
+++ b/lib/tasks/helpers/dns.rb
@@ -12,7 +12,7 @@ module Dns
   def create_dns_entity_from_string(s, alias_entity=nil, unscoped=false)
     return nil unless s && s.length > 0
 
-    entity_details = { "name" => s }
+    entity_details = { "name" => s.gsub("domain: ","").gsub("*.","") }
     entity_details.merge!({"unscoped" => true }) if unscoped
 
     if s.is_ip_address?


### PR DESCRIPTION
Neat endpoint provided by @erbbysam out of his Defcon 27 "Hunting Certificates & Servers" talk. Data is currently updated weekly according to his notes. 

Slides here: https://cdn.shopify.com/s/files/1/0177/9886/files/phv2019-serb.pdf

Basically, his tooling looks across the public internet for systems running on :443, grabs the cert (through a neat faster half-connection method), and parses out the hostnames.  He then caches these results and provides it as an endpoint. This task hits his endpoint for a given domain or DnsRecord, which is - FAST - almost certainly due to same the sorting method used in DNSGrep,  and returns the results as new entities. 

Example of usage: 
![image](https://user-images.githubusercontent.com/76854/85208152-b1529d80-b2f3-11ea-8a54-57ed1fce3c44.png)
