### PR TITLE
check and issue for CVE-2020-16875

### DIFF
--- a/lib/issues/microsoft_exchange_cve_2020_16875.rb
+++ b/lib/issues/microsoft_exchange_cve_2020_16875.rb
@@ -1,0 +1,34 @@
+module Intrigue
+  module Issue
+  class VulnExchangeCve202016875 < BaseIssue
+
+    def self.generate(instance_details={})
+      {
+        added: "2020-09-11",
+        name: "microsoft_exchange_cve_2020_0688",
+        pretty_name: "Microsoft Exchange Server DlpUtils AddTenantDlpPolicy Remote Code Execution Vulnerabilit (CVE-2020-16875)",
+        identifiers: [
+          { type: "CVE", name: "CVE-2020-16875" }
+        ],
+        severity: 1,
+        status: "potential",
+        category: "vulnerability",
+        description: "This vulnerability allows remote attackers to execute arbitrary code on affected installations of Exchange Server. Authentication is required to exploit this vulnerability. The specific flaw exists within the processing of the New-DlpPolicy cmdlet. The issue results from the lack of proper validation of user-supplied template data when creating a dlp policy. An attacker can leverage this vulnerability to execute code in the context of SYSTEM.",
+        remediation: "",
+        affected_software: [
+          { :vendor => "Microsoft", :product => "Exchange Server", :version => "2016", :update => "Cumulative Update 16" },
+          { :vendor => "Microsoft", :product => "Exchange Server", :version => "2016", :update => "Cumulative Update 17" },
+          { :vendor => "Microsoft", :product => "Exchange Server", :version => "2019", :update => "Cumulative Update 5" },
+          { :vendor => "Microsoft", :product => "Exchange Server", :version => "2019", :update => "Cumulative Update 6" }
+        ],
+        references: [
+          { type: "description", uri: "https://portal.msrc.microsoft.com/en-us/security-guidance/advisory/CVE-2020-16875"},
+          { type: "description", uri: "https://srcincite.io/advisories/src-2020-0019/"},
+        ],
+        check: "vuln/microsoft_exchange_cve_2020_16875"
+      }.merge!(instance_details)
+    end
+
+  end
+  end
+  end

--- a/lib/tasks/vuln/microsoft_exchange_cve_2020_16875.rb
+++ b/lib/tasks/vuln/microsoft_exchange_cve_2020_16875.rb
@@ -1,0 +1,60 @@
+module Intrigue
+module Task
+class MicrosoftExchangeCve202016875 < BaseTask
+
+  def self.metadata
+    {
+      :name => "vuln/microsoft_exchange_cve_2020_16875",
+      :pretty_name => "Vuln Check - Microsoft Exchange RCE (CVE-2020-16875) ",
+      :authors => ["shpendk","jcran"],
+      :identifiers => [{ "cve" =>  "CVE-2020-16875" }],
+      :description => "This task does a version check for CVE-2020-16875 in Microsoft Exchange",
+      :references => ["https://portal.msrc.microsoft.com/en-us/security-guidance/advisory/CVE-2020-16875"],
+      :type => "vuln_check",
+      :passive => false,
+      :allowed_types => ["Uri"],
+      :example_entities => [{"type" => "Uri", "details" => {"name" => "https://intrigue.io"}}],
+      :allowed_options => [{:name => "force", :regex => "boolean", :default => false }],
+      :created_types => []
+    }
+  end
+
+  ## Default method, subclasses must override this
+  def run
+    super
+
+    # first, ensure we're fingerprinted
+    require_enrichment
+    fingerprint = _get_entity_detail("fingerprint")
+
+    if is_product?(fingerprint, "Exchange Server")
+      if is_vulnerable_version?(fingerprint)
+          _create_linked_issue("microsoft_exchange_cve_2020_16875")
+      end
+    end
+  end
+
+  def is_vulnerable_version?(fingerprint)
+    # check the fingerprints
+    fp = fingerprint.select{|v| v['product'] == "Exchange Server" }.first
+    return false unless fp
+
+    vulnerable_versions.include?({version: fp["version"], update: fp["update"]})
+  end
+
+  def vulnerable_versions
+    vulnerable_versions = [
+
+      # 2016
+      { version: "2016", update: "Cumulative Update 16" },
+      { version: "2016", update: "Cumulative Update 17" },
+
+      # 2019
+      { version: "2019", update: "Cumulative Update 5" },
+      { version: "2019", update: "Cumulative Update 6" },
+    ]
+  end
+
+end
+end
+end


### PR DESCRIPTION
Check and issue for CVE-2020-16875. Currently only as a version check with a status of `potential`. Full poc requires user with specific role (see [here](https://srcincite.io/advisories/src-2020-0019/)) 