### PR TITLE
Mobileiron multiple cves

### DIFF
--- a/lib/issues/mobileiron_multiple_cves.rb
+++ b/lib/issues/mobileiron_multiple_cves.rb
@@ -1,0 +1,35 @@
+module Intrigue
+  module Issue
+  class MobileIronCve202015506 < BaseIssue
+
+    def self.generate(instance_details={})
+      {
+        added: "2020-09-15",
+        name: "mobileiron_multiple_cves",
+        pretty_name: "MobileIron Multiple CVEs",
+        identifiers: [
+          { type: "CVE", name: "CVE-2020-15505" },
+          { type: "CVE", name: "CVE-2020-15506" },
+          { type: "CVE", name: "CVE-2020-15507" },
+        ],
+        severity: 1,
+        category: "vulnerability",
+        status: "potential",
+        description: "Multiple vulnerabilities in MobileIron Core, Connector, Cloud, Sentry and Reporting Database (RDB) versions 10.6 and earlier could allow an attacker to execute remote exploits without authentication.",
+        remediation: "Apply patches released on June 15,2020",
+        affected_software: [
+          { :vendor => "MobileIron", :product => "Core" }
+        ],
+        references: [ # types: description, remediation, detection_rule, exploit, threat_intel
+          { type: "description", uri: "https://nvd.nist.gov/vuln/search/results?form_type=Advanced&cves=on&cpe_version=cpe%3a%2fa%3amobileiron%3acore%3a10.6" },
+          { type: "exploit", uri: "https://blog.orange.tw/2020/09/how-i-hacked-facebook-again-mobileiron-mdm-rce.html" },
+          { type: "remediation", uri: "https://www.mobileiron.com/en/blog/mobileiron-security-updates-available" },
+
+        ],
+        check: "vuln/mobileiron_multiple_cves"
+      }.merge!(instance_details)
+    end
+
+  end
+  end
+  end

--- a/lib/tasks/vuln/mobileiron_multiple_cves.rb
+++ b/lib/tasks/vuln/mobileiron_multiple_cves.rb
@@ -1,0 +1,58 @@
+module Intrigue
+module Task
+class MobileIronCve202015506 < BaseTask
+
+  def self.metadata
+    {
+      :name => "vuln/mobileiron_multiple_cves",
+      :pretty_name => "Vuln Check - MobileIron Multiple CVEs (CVE-2020-15505, CVE-2020-15506, CVE-2020-15507) ",
+      :authors => ["shpendk","jcran"],
+      :identifiers => [{ "cve" =>  "CVE-2020-15505" }, { "cve" =>  "CVE-2020-15506" }, { "cve" =>  "CVE-2020-15507" }],
+      :description => "This task does a version check for multiple MobileIron vulnerabilities",
+      :references => ["https://nvd.nist.gov/vuln/search/results?form_type=Advanced&cves=on&cpe_version=cpe%3a%2fa%3amobileiron%3acore%3a10.6"],
+      :type => "vuln_check",
+      :passive => false,
+      :allowed_types => ["Uri"],
+      :example_entities => [{"type" => "Uri", "details" => {"name" => "https://intrigue.io"}}],
+      :created_types => []
+    }
+  end
+
+  ## Default method, subclasses must override this
+  def run
+    super
+
+    require_enrichment
+
+    # check our fingerprints for a version
+    our_version = nil
+    fp = _get_entity_detail("fingerprint")
+    fp.each do |f|
+      if f["product"] == "MobileIron" && f["version"] != ""
+        our_version = f["version"]
+        break
+      end
+    end
+
+    if our_version
+      _log "Got version: #{our_version}"
+    else
+      _log_error "Unable to get version, failing"
+      return
+    end
+
+    # check the version to see if its vulnerable.
+    # versions smaller than 10.6 are vulnerable as per https://www.mobileiron.com/en/blog/mobileiron-security-updates-available
+    _log "Checking version against known vulnerable versions"
+
+    if ::Versionomy.parse(our_version) <= ::Versionomy.parse("10.6")
+      _log_good "Vulnerable!"
+      _create_linked_issue "mobileiron_multiple_cves"
+    else
+      _log "Not vulnerable!"
+    end
+  end
+
+end
+end
+end

--- a/lib/tasks/vuln/mobileiron_multiple_cves.rb
+++ b/lib/tasks/vuln/mobileiron_multiple_cves.rb
@@ -28,7 +28,7 @@ class MobileIronCve202015506 < BaseTask
     our_version = nil
     fp = _get_entity_detail("fingerprint")
     fp.each do |f|
-      if f["product"] == "MobileIron" && f["version"] != ""
+      if f["vendor"] == "MobileIron" && f["product"] == "Core" && f["version"] != ""
         our_version = f["version"]
         break
       end


### PR DESCRIPTION
This check is tested and works fine:
```
[_] Options: []
[_] Starting task run at 2020-09-15 23:19:04 UTC!
[_] Waiting up to 10m for entity to be enriched... (199 / 200)
[_] Waiting up to 10m for entity to be enriched... (198 / 200)
[_] Waiting up to 10m for entity to be enriched... (197 / 200)
[_] Waiting up to 10m for entity to be enriched... (196 / 200)
[_] Waiting up to 10m for entity to be enriched... (195 / 200)
[_] Waiting up to 10m for entity to be enriched... (194 / 200)
[_] Waiting up to 10m for entity to be enriched... (193 / 200)
[_] Waiting up to 10m for entity to be enriched... (192 / 200)
[_] {"cpe"=>"cpe:2.3:a:oracle:java::", "hide"=>false, "tags"=>["Web Framework"], "type"=>"fingerprint", "tasks"=>nil, "issues"=>nil, "method"=>"ident", "update"=>"", "vendor"=>"Oracle", "product"=>"Java", "version"=>"", "inference"=>false, "match_type"=>"content_cookies", "match_details"=>"JSESSIONID cookie"}
[_] {"cpe"=>"cpe:2.3:a:bootstrap:bootstrap::", "hide"=>false, "tags"=>["Web Framework"], "type"=>"fingerprint", "tasks"=>nil, "issues"=>nil, "method"=>"ident", "update"=>"", "vendor"=>"Bootstrap", "product"=>"Bootstrap", "version"=>"", "inference"=>false, "match_type"=>"content_body", "match_details"=>"boostrap css"}
[_] {"cpe"=>"cpe:2.3:a:mobileiron:core::", "hide"=>false, "tags"=>["MDM"], "type"=>"fingerprint", "tasks"=>nil, "issues"=>nil, "method"=>"ident", "update"=>"", "vendor"=>"MobileIron", "product"=>"Core", "version"=>"", "inference"=>false, "match_type"=>"content_body", "match_details"=>"favicon"}
[_] {"cpe"=>"cpe:2.3:a::::", "hide"=>false, "tags"=>["Web Server", "Application Server"], "type"=>"fingerprint", "tasks"=>nil, "issues"=>nil, "method"=>"ident", "update"=>"", "vendor"=>nil, "product"=>nil, "version"=>"", "inference"=>false, "match_type"=>"content_headers", "match_details"=>"Server server header. This header is usually used by Web Servers or Application Servers."}
[_] {"cpe"=>"cpe:2.3:a:mobileiron:core:10.2:", "hide"=>false, "tags"=>["MDM"], "type"=>"fingerprint", "tasks"=>nil, "vulns"=>[], "issues"=>nil, "method"=>"ident", "update"=>"", "vendor"=>"MobileIron", "product"=>"Core", "version"=>"10.2", "inference"=>true, "match_type"=>"content_body", "match_details"=>"version via css file"}
[_] Got version: 10.2
[_] Checking version against known vulnerable versions
[+] Vulnerable!
[+] Creating linked issue of type: mobileiron_multiple_cves
[_] Notifying via default channels
[_] Task run finished at 2020-09-15 23:19:51 UTC!
[_] Not an enrichment task, skipping machine generation
[_] Task complete. Ship it!
```