### PR TITLE
Fixes the problem where an empty string is returned in the version.

### DIFF
--- a/lib/tasks/vuln/sonatype_nexus_cve_2020_10204.rb
+++ b/lib/tasks/vuln/sonatype_nexus_cve_2020_10204.rb
@@ -1,7 +1,7 @@
 module Intrigue
   module Task
   class SonatypeNexusCve202010204 < BaseTask
-  
+
     def self.metadata
       {
         :name => "vuln/sonatype_nexus_cve_2020_10204",
@@ -25,13 +25,13 @@ module Intrigue
         :created_types => []
       }
     end
-  
+
     ## Default method, subclasses must override this
     def run
       super
-  
+
       require_enrichment
-  
+
       ###
       ### Just check version, as this requires an autheenticated account to exploit
       ###
@@ -40,26 +40,26 @@ module Intrigue
       our_version = nil
       fp = _get_entity_detail("fingerprint")
       fp.each do |f|
-        if f["product"] == "Nexus Repository Manager" && f["version"]
+        if f["product"] == "Nexus Repository Manager" && f["version"] != ""
           our_version = f["version"]
           break
         end
       end
-      
+
       if our_version
         _log "Got version: #{our_version}"
-      else 
+      else
         _log_error "Unable to get version, failing"
-        return 
+        return
       end
 
       if ::Versionomy.parse(our_version) <= ::Versionomy.parse("3.21.1")
         _log_good "Vulnerable!"
         _create_linked_issue "sonatype_nexus_cve_2020_10204"
-        return 
-      end 
+        return
+      end
 
-      
+
       ###
       ### In the future, consider an actual exploit, if user creds are provided
       ###
@@ -67,8 +67,8 @@ module Intrigue
       #uri = _get_entity_name
       #hostname = URI.parse(uri).hostname.to_s
       #csrf_token = "8d0c3bff-fe84-408e-a60d-c1c49eb07a17"
-      #cookie = "NX-ANTI-CSRF-TOKEN=#{csrf_token}; Path=/"      
-      
+      #cookie = "NX-ANTI-CSRF-TOKEN=#{csrf_token}; Path=/"
+
       #headers = {
       #  "Host" => "#{hostname}",
       #  "Referer" => "#{uri}",
@@ -96,15 +96,14 @@ module Intrigue
 
       #if response.code == "200" && response.body_utf8 =~ /1787569/
       #  _create_linked_issue "sonatype_nexus_cve_2020_10204", {"proof" => response.body_utf8 }
-      #else 
+      #else
       #  _log "Not vulnerable!"
       #  _log "Got response: #{response.code} #{response.body_utf8}"
       #end
-      
-  
+
+
     end
-  
+
   end
   end
   end
-  

--- a/lib/tasks/vuln/webmin_pwreset_cve_2019_15107.rb
+++ b/lib/tasks/vuln/webmin_pwreset_cve_2019_15107.rb
@@ -36,7 +36,7 @@ class  WebminPwresetCve201915107 < BaseTask
     our_version = nil
     fp = _get_entity_detail("fingerprint")
     fp.each do |f|
-      if f["product"] == "Webmin" && f["version"]
+      if f["product"] == "Webmin" && f["version"] != ""
         our_version = f["version"]
         break
       end
@@ -57,32 +57,32 @@ class  WebminPwresetCve201915107 < BaseTask
         res = http_request :post, url, nil, headers
 
         # make sure we got a response
-        unless res 
+        unless res
           _log "Not vulnerable, no response!"
           return
         end
 
-        # check to see if we got a failure immediately 
-        if res.code == 500 && res.body =~ /Password changing is not enabled/ 
+        # check to see if we got a failure immediately
+        if res.code == 500 && res.body =~ /Password changing is not enabled/
           _log "Not vulnerable, Password changing not enabled!"
           return
         end
 
         ### okay if we made it this far, create an issue
-        _create_linked_issue( "vulnerability_webmin_cve_2019_15107") 
-      else 
+        _create_linked_issue( "vulnerability_webmin_cve_2019_15107")
+      else
         _log "Version #{our_version} is newer than vulnerable version: #{vulnerable_version}"
 
-      end 
+      end
 
-    else 
+    else
       _log_error "Unable to get version, failing"
-      return 
+      return
     end
 
   end
 
- 
+
 end
 end
 end


### PR DESCRIPTION
There is currently a problem when vuln checks rely on version comparison, but the fingerprint returns an empty string. This is a temporary fix, as I think a better way must be found to handle empty versions in fingerprints.