### PR TITLE
check and issue for citrix CVE-2020-8194

### DIFF
--- a/lib/issues/citrix_netscaler_codeinjection_cve_2020_8194.rb
+++ b/lib/issues/citrix_netscaler_codeinjection_cve_2020_8194.rb
@@ -20,7 +20,8 @@ module Intrigue
         references: [
           { type: "description", uri: "https://nvd.nist.gov/vuln/detail/CVE-2020-8194" },
           { type: "exploit", uri: "https://www.rapid7.com/db/vulnerabilities/citrix-adc-cve-2020-8194" }
-        ]
+        ], 
+        check: "vuln/citrix_netscaler_codeinjection_cve_2020_8194"
       }.merge!(instance_details)
     end
 

--- a/lib/issues/citrix_netscaler_codeinjection_cve_2020_8194.rb
+++ b/lib/issues/citrix_netscaler_codeinjection_cve_2020_8194.rb
@@ -1,0 +1,29 @@
+module Intrigue
+  module Issue
+  class CitrixNetscalerCve20208194 < BaseIssue
+
+    def self.generate(instance_details={})
+      {
+        added: "2020-09-16",
+        name: "citrix_netscaler_codeinjection_cve_2020_8194",
+        pretty_name: "Vulnerable Citrix Netscaler (CVE-2020-8194)",
+        identifiers: [
+          { type: "CVE", name: "CVE-2020-8194" }
+        ],
+        severity: 3,
+        category: "vulnerability",
+        status: "confirmed",
+        description: "A reflected code injection in Citrix ADC and Citrix Gateway versions before 13.0-58.30, 12.1-57.18, 12.0-63.21, 11.1-64.14 and 10.5-70.18 and Citrix SDWAN WAN-OP versions before 11.1.1a, 11.0.3d and 10.2.7 allows the modification of a file download.",
+        affected_software: [
+          { :vendor => "Citrix", :product => "NetScaler Gateway (Management Inteface)" }
+        ],
+        references: [
+          { type: "description", uri: "https://nvd.nist.gov/vuln/detail/CVE-2020-8194" },
+          { type: "exploit", uri: "https://www.rapid7.com/db/vulnerabilities/citrix-adc-cve-2020-8194" }
+        ]
+      }.merge!(instance_details)
+    end
+
+  end
+  end
+  end

--- a/lib/tasks/vuln/citrix_netscaler_codeinjection_cve_2020_8194.rb
+++ b/lib/tasks/vuln/citrix_netscaler_codeinjection_cve_2020_8194.rb
@@ -1,0 +1,54 @@
+module Intrigue
+module Task
+class  CitrixNetscalerCve20208194 < BaseTask
+
+  def self.metadata
+    {
+      :name => "vuln/citrix_netscaler_codeinjection_cve_2020_8194",
+      :pretty_name => "Vuln Check - Citrix Netscaler Code Injection (CVE-2019-8194)",
+      :authors => ["shpendk","jcran"],
+      :description => "This task checks a Citrix Netscaler for the CVE-2019-8194 code injection vulnerability.",
+      :type => "vuln_check",
+      :passive => false,
+      :allowed_types => ["Uri"],
+      :example_entities => [{"type" => "Uri", "details" => {"name" => "https://intrigue.io"}}],
+      :allowed_options => [],
+      :created_types => []
+    }
+  end
+
+  ## Default method, subclasses must override this
+  def run
+    super
+
+    require_enrichment
+
+    url = _get_entity_name
+
+    # make request and save response
+    response = http_request :get, "#{url}/menu/guiw?nsbrand=1&protocol=nonexistent.1337\">&id=3&nsvpx=phpinfo"
+    unless response && response.code.to_i == 200
+      _log "No response! Failing"
+      return
+    end
+
+    # grab response headers and body
+    response_headers = response.headers
+    response_body = response.body_utf8
+
+    # check if header and body contain needed values
+    if response_headers.has_value?("application/x-java-jnlp-file")
+      # header is present, check for response body
+      if response_body =~ /\<jnlp codebase\=\"nonexistent\.1337\"/
+        _log "Vulnerable!"
+        _create_linked_issue "citrix_netscaler_codeinjection_cve_2020_8194" , { "proof" => response }
+      end
+    else
+      _log "Not vulnerable!"
+    end
+
+  end
+
+end
+end
+end


### PR DESCRIPTION
This is the issue and check for Citrix CVE-2020-8194. It has been tested and works as expected:
```
[_] Options: []
[_] Starting task run at 2020-09-16 21:53:41 UTC!
[_] Vulnerable!
[+] Creating linked issue of type: citrix_netscaler_codeinjection_cve_2020_8194
[_] Task run finished at 2020-09-16 21:53:41 UTC!
[_] Not an enrichment task, skipping machine generation
[_] Task complete. Ship it!
```