### PR TITLE
Check and issue for CVE-2020-14179

### DIFF
--- a/lib/issues/atlassian_dataexposure_cve_2020_14179.rb
+++ b/lib/issues/atlassian_dataexposure_cve_2020_14179.rb
@@ -1,0 +1,33 @@
+module Intrigue
+    module Issue
+    class AtlassianCve202014179 < BaseIssue
+  
+      def self.generate(instance_details={})
+        {
+          added: "2020-09-22",
+          name: "atlassian_dataexposure_cve_2020_14179",
+          pretty_name: "Atlassian Sensitive Data Exposure CVE-2020-14179",
+          identifiers: [
+            { type: "CVE", name: "CVE-2020-14179" }
+          ],
+          severity: 3,
+          category: "vulnerability",
+          status: "potential",
+          description: "Affected versions of Atlassian Jira Server and Data Center allow remote, unauthenticated attackers to view custom field names and custom SLA names via an Information Disclosure vulnerability in the /secure/QueryComponent!Default.jspa endpoint. The affected versions are before version 8.5.8, and from version 8.6.0 before 8.11.1.",
+          remediation: "Update to version 8.5.8, 8.11.1 or 8.12.0 respectively.",
+          affected_software: [
+            { :vendor => "Atlassian", :product => "Jira" }
+          ],
+          references: [ # types: description, remediation, detection_rule, exploit, threat_intel
+            { type: "description", uri: "https://nvd.nist.gov/vuln/detail/CVE-2020-14179" },
+            { type: "remediation", uri: "https://jira.atlassian.com/browse/JRASERVER-71536" },
+  
+          ],
+          check: "vuln/atlassian_dataexposure_cve_2020_14179"
+        }.merge!(instance_details)
+      end
+  
+    end
+    end
+    end
+  

--- a/lib/tasks/vuln/atlassian_dataexposure_cve_2020_14179.rb
+++ b/lib/tasks/vuln/atlassian_dataexposure_cve_2020_14179.rb
@@ -1,0 +1,54 @@
+module Intrigue
+    module Task
+    class AtlassianCve202014179 < BaseTask
+    
+      def self.metadata
+        {
+          :name => "vuln/atlassian_dataexposure_cve_2020_14179",
+          :pretty_name => "Vuln Check - Atlassian Sensitive Data Exposure CVE-2020-14179",
+          :authors => ["shpendk","jcran"],
+          :identifiers => [{ "cve" =>  "CVE-2020-14179" }],
+          :description => "This task performs a vulnerability check for CVE-2020-14179",
+          :references => ["https://nvd.nist.gov/vuln/detail/CVE-2020-14179"],
+          :type => "vuln_check",
+          :passive => false,
+          :allowed_types => ["Uri"],
+          :example_entities => [{"type" => "Uri", "details" => {"name" => "https://intrigue.io"}}],
+          :created_types => []
+        }
+      end
+    
+      ## Default method, subclasses must override this
+      def run
+        super
+    
+        #require_enrichment
+    
+        # make the request
+        path = "/secure/QueryComponent!Default.jspa"
+        uri = _get_entity_name
+        response = http_request :get, "#{uri}#{path}"
+
+        # fail if no response
+        unless response && response.body_utf8 
+            _log "No response! Failing"
+            return
+        end        
+        
+    
+        # check response code and content
+        if response.code.to_i == 200
+            if response.body_utf8 =~ /searchers/
+                _log "Vulnerable!"
+                # file issue
+                _create_linked_issue("atlassian_dataexposure_cve_2020_14179", { 
+                  status: "confirmed",
+                  proof: response.body_utf8 })
+            end
+        end
+    end
+    
+    end
+    end
+    end
+    

--- a/lib/tasks/vuln/atlassian_dataexposure_cve_2020_14179.rb
+++ b/lib/tasks/vuln/atlassian_dataexposure_cve_2020_14179.rb
@@ -9,7 +9,7 @@ module Intrigue
           :authors => ["shpendk","jcran"],
           :identifiers => [{ "cve" =>  "CVE-2020-14179" }],
           :description => "This task performs a vulnerability check for CVE-2020-14179",
-          :references => ["https://nvd.nist.gov/vuln/detail/CVE-2020-14179"],
+          :references => ["https://github.com/projectdiscovery/nuclei-templates/pull/487"],
           :type => "vuln_check",
           :passive => false,
           :allowed_types => ["Uri"],


### PR DESCRIPTION
Check and issue for Atlassian CVE-20202-14179. Tested and works as expected:
```
[_] Options: []
[_] Starting task run at 2020-09-22 17:56:15 UTC!
[_] Vulnerable!
[+] Creating linked issue of type: atlassian_dataexposure_cve_2020_14179
[_] Task run finished at 2020-09-22 17:56:16 UTC!
[_] Not an enrichment task, skipping machine generation
[_] Task complete. Ship it!
```