### PR TITLE
Helper to get certficate details from host

### DIFF
--- a/lib/tasks/base.rb
+++ b/lib/tasks/base.rb
@@ -18,6 +18,7 @@ class BaseTask
   include Intrigue::Task::WebContent
   include Intrigue::Task::WebAccount
   include Intrigue::Task::Whois
+  include Intrigue::Task::TlsHandler
 
   include Sidekiq::Worker
   sidekiq_options :queue => "task", :backtrace => true

--- a/lib/tasks/helpers/tls_handler.rb
+++ b/lib/tasks/helpers/tls_handler.rb
@@ -2,6 +2,18 @@ module Intrigue
   module Task
     module TlsHandler
     
+      def get_certificate(hostname, port, timeout=30)
+        # connect
+        socket = connect_ssl_socket(hostname,port,timeout)
+        return nil unless socket && socket.peer_cert
+        # Grab the cert
+        cert = OpenSSL::X509::Certificate.new(socket.peer_cert)
+        # parse the cert
+        socket.sysclose
+        # get the names
+        cert
+      end
+      
       def get_certificate_details(hostname, port)
         # connect
         socket = connect_ssl_socket(hostname,port,timeout=30)

--- a/lib/tasks/helpers/tls_handler.rb
+++ b/lib/tasks/helpers/tls_handler.rb
@@ -1,0 +1,40 @@
+module Intrigue
+  module Task
+    module TlsHandler
+    
+      def get_certificate_details(hostname, port)
+        # connect
+        socket = connect_ssl_socket(hostname,port,timeout=30)
+            
+        unless socket && socket.peer_cert 
+          _log_error "Failed to extract certificate."
+          return
+        end
+
+        # Parse the cert
+        cert = OpenSSL::X509::Certificate.new(socket.peer_cert)
+
+        # Create an SSL Certificate entity
+        key_size = "#{cert.public_key.n.num_bytes * 8}" if cert.public_key && cert.public_key.respond_to?(:n)
+        certificate_details = {
+          "name" => "#{cert.subject.to_s.split("CN=").last} (#{cert.serial})",
+          "version" => cert.version,
+          "serial" => "#{cert.serial}",
+          "not_before" => "#{cert.not_before}",
+          "not_after" => "#{cert.not_after}",
+          "subject" => "#{cert.subject}",
+          "issuer" => "#{cert.issuer}",
+          "key_length" => key_size,
+          "signature_algorithm" => "#{cert.signature_algorithm}",
+          "hidden_text" => "#{cert.to_text}"
+        }
+
+        # _log "Got certificat edetails #{certificate_details}"
+
+        #return information
+        certificate_details
+      end
+    
+    end
+    end
+    end

--- a/lib/tasks/helpers/web.rb
+++ b/lib/tasks/helpers/web.rb
@@ -259,14 +259,9 @@ module Task
 
   def connect_ssl_socket_get_cert(hostname,port,timeout=15)
     # connect
-    socket = connect_ssl_socket(hostname,port,timeout)
-    return nil unless socket && socket.peer_cert
-    # Grab the cert
-    cert = OpenSSL::X509::Certificate.new(socket.peer_cert)
-    # parse the cert
-    socket.sysclose
-    # get the names
-  cert
+    cert = get_certificate(hostname, port, timeout)
+    return nil unless cert
+    cert
   end
 
 

--- a/lib/tasks/uri_gather_ssl_certificate.rb
+++ b/lib/tasks/uri_gather_ssl_certificate.rb
@@ -34,32 +34,17 @@ class UriGatherSslCert  < BaseTask
       hostname = URI.parse(uri).host
       port = URI.parse(uri).port
 
-      # connect
-      socket = connect_ssl_socket(hostname,port,timeout=30)
+      # use helper function to grab certificate details
+      certificate_details = get_certificate_details hostname, port
 
-      return [] unless socket && socket.peer_cert
+      # return if no details were provided
+      return [] unless certificate_details
 
-      # Parse the cert
-      cert = OpenSSL::X509::Certificate.new(socket.peer_cert)
-
-      # Create an SSL Certificate entity
-      key_size = "#{cert.public_key.n.num_bytes * 8}" if cert.public_key && cert.public_key.respond_to?(:n)
-      certificate_details = {
-        "name" => "#{cert.subject.to_s.split("CN=").last} (#{cert.serial})",
-        "version" => cert.version,
-        "serial" => "#{cert.serial}",
-        "not_before" => "#{cert.not_before}",
-        "not_after" => "#{cert.not_after}",
-        "subject" => "#{cert.subject}",
-        "issuer" => "#{cert.issuer}",
-        "key_length" => key_size,
-        "signature_algorithm" => "#{cert.signature_algorithm}",
-        "hidden_text" => "#{cert.to_text}"
-      }
+      # create certificate entity
       _create_entity "SslCertificate", certificate_details
 
     # one way to detect self-signed
-    if cert.subject == cert.issuer
+    if certificate_details["subject"] == certificate_details["issuer"]
       ############################################
       ####            Old Issue              ####
       ###########################################


### PR DESCRIPTION
This is a helper, currently with only 1 function: get_certificate_details. It uses `OpenSSL` to go grab the certificate from the port, and returns the following details about the certificate:
* name
* version
* serial
* not_before
* not_after
* subject
* issuer
* key_length
* signature_algorithm
* hidden_text