### PR TITLE
typo in uri_brute.rb

### DIFF
--- a/lib/tasks/uri_brute.rb
+++ b/lib/tasks/uri_brute.rb
@@ -127,7 +127,7 @@ class UriBrute < BaseTask
     return false unless response
 
     # try again if we got a blank page (some WAFs seem to do this?)
-    if response.body_utf8 = ""
+    if response.body_utf8 == ""
       10.times do
         _log "Re-attempting #{request_uri}... verifying we should really have a blank page"
         response = http_request :get, request_uri


### PR DESCRIPTION
Hi team,

In `lib/tasks/uri_brute.rb` there is a small typo which causes the script to error out:

```
if response.body_utf8 = ""
      10.times do
        <snipped for brevity>
```

Based on the logic of the code it is comparing the two values to check if `response.body_utf8` is empty however due to a small typo (missing an `=`) it instead tries to assign the value and thus the script errors out.

Best regards,
Maxim