### PR TITLE
Reverse whois improvement

### DIFF
--- a/lib/tasks/search_whoisology.rb
+++ b/lib/tasks/search_whoisology.rb
@@ -11,35 +11,101 @@ class SearchWhoisology < BaseTask
       :references => [],
       :type => "discovery",
       :passive => true,
-      :allowed_types => ["Domain","DnsRecord", "EmailAddress"],
+      :allowed_types => ["Domain","DnsRecord", "EmailAddress", "UniqueKeyword"],
       :example_entities => [{"type" => "EmailAddress", "details" => {"name" => "intrigue.io"}}],
       :allowed_options => [],
       :created_types => ["DnsRecord","Info"]
     }
   end
 
-  ## Default method, subclasses must override this
+  def search_whoisology_by_email(api_key, email_address)
+    _log "Searching whoisology by email"
+    begin 
+      # Attach to the whoisology service & search
+      whoisology = Whoisology::Api.new(api_key)
+
+      # Run a PING to see if we have any results
+      result = whoisology.ping "email", email_address
+      _log "Got #{result}"
+      _log "Got #{result["count"]} results for email search"
+      return if result["count"].to_i == 0
+
+      # do the actual search with the FLAT comman      
+      result = whoisology.flat "email", email_address
+      _log_good "Creating entities for #{result["count"]} results."
+    
+      if result["domains"]
+        result["domains"].each {|d| 
+          _create_entity "Domain", {"name" => d["domain_name"]} }
+      else
+        _log_error "No domains, do we have API credits?"
+      end
+    rescue RestClient::Forbidden => e 
+      _log_error "Error when querying whoisology (forbidden)"
+    end
+  end
+
+  def search_whoisology_by_keyword(api_key, keyword)
+    _log "Searching whoisology by keyword"
+    begin 
+      # Attach to the whoisology service & search
+      whoisology = Whoisology::Api.new(api_key)
+
+      # Run a PING to see if we have any results
+      result = whoisology.ping "organization", keyword
+      _log "Got #{result}"
+      _log "Got #{result["count"]} results for organizaiton search"
+      return if result["count"].to_i == 0
+
+      # do the actual search with the FLAT command
+      result = whoisology.flat "organization", keyword
+      _log_good "Creating entities for #{result["count"]} results."
+    
+      if result["domains"]
+        result["domains"].each {|d| 
+          _create_entity "Domain", {"name" => d["domain_name"]} }
+      else
+        _log_error "No domains, do we have API credits?"
+      end
+    rescue RestClient::Forbidden => e 
+      _log_error "Error when querying whoisology (forbidden)"
+    end
+  end
+
+
+  
   def run
     super
 
     begin
-
-      # Make sure the key is set
+      # get values
       api_key = _get_task_config "whoisology_api_key"
       entity_name = _get_entity_name
+
+      # make sure values are set
+      unless entity_name
+        # Something went wrong with the lookup?
+        _log "Unable to get entity value"
+        return
+      end
+
+      unless api_key
+        _log_error "No api_key?"
+        return
+      end
 
       case _get_entity_type_string
 
         when "EmailAddress"
           
-          entity_type = "email"
+          search_whoisology_by_email api_key, entity_name
 
         when "DnsRecord", "Domain"
 
           ## When we have a Domain or DnsRecord, we need to do a lookup on the current record,
           ## grab the email address, and then do the search based on that email
 
-          _log "Looking up contacts for domain"
+          _log "Looking up contacts for domain #{entity_name}"
           begin
             # We're going to pull the domain's email address....
             whois = ::Whois::Client.new(:timeout => 20)
@@ -50,48 +116,18 @@ class SearchWhoisology < BaseTask
           rescue Timeout::Error => e
             _log_error "Unable to lookup #{entity_name}... try a manual lookup"
             return nil
+          rescue ::Whois::Error => e
+            _log_error "Whois Exception #{e.class}: #{e.message}" 
+            return nil
+          rescue StandardError => e
+            _log_error "Application Exception #{e.class}: #{e.message}"
           end
 
-          entity_name = contact_emails.first
-          entity_type = "email"
-      end
+          contact_emails_unique = contact_emails.uniq
+          contact_emails_unique.each { |email| search_whoisology_by_email api_key, email } 
 
-      _log "Got entity: #{entity_type} #{entity_name}"
-
-      unless entity_name
-        # Something went wrong with the lookup?
-        _log "Unable to get a current email address"
-        return
-      end
-
-      unless api_key
-        _log_error "No api_key?"
-        return
-      end
-
-      begin 
-        # Attach to the whoisology service & search
-        whoisology = Whoisology::Api.new(api_key)
-
-        # Run a PING to see if we have any results
-        result = whoisology.ping entity_type, entity_name
-        _log "Got #{result}"
-        _log "Got #{result["count"]} results"
-        return if result["count"].to_i == 0
-
-        # do the actual search with the FLAT command
-        result = whoisology.flat entity_type, entity_name
-
-        _log_good "Creating entities for #{result["count"]} results."
-      
-        if result["domains"]
-          result["domains"].each {|d| 
-            _create_entity "Domain", {"name" => d["domain_name"]} }
-        else
-          _log_error "No domains, do we have API credits?"
-        end
-      rescue RestClient::Forbidden => e 
-        _log_error "Error when querying whoisology (forbidden)"
+        when "UniqueKeyword"
+          search_whoisology_by_keyword api_key, entity_name
       end
 
     end

--- a/lib/tasks/search_whoisxmlapi.rb
+++ b/lib/tasks/search_whoisxmlapi.rb
@@ -1,0 +1,69 @@
+module Intrigue
+    module Task
+    class WhoisXmlApi < BaseTask
+      include Intrigue::Task::Web
+    
+      def self.metadata
+        {
+          :name => "search_whoisxmlapi",
+          :pretty_name => "Search WhoisXMLAPI (Reverse Whois)",
+          :authors => ["shpendk"],
+          :description => "This task hits the WhoisXMLAPI reverse whois API and returns records that match the given email or keywoard",
+          :references => ["https://reverse-whois.whoisxmlapi.com/api/documentation/making-requests"],
+          :type => "discovery",
+          :passive => true,
+          :allowed_types => ["Domain", "EmailAddress", "Organization", "Person", "UniqueKeyword"],
+          :example_entities => [ {"type" => "Organization", "details" => {"name" => "Intrigue Corp"}} ],
+          :allowed_options => [
+          #  {:name => "exclude_term", :regex => "alpha_numeric" , :default => "" }
+          ],
+          :created_types => ["Domain"]
+        }
+      end
+    
+      def run
+        super
+        
+        uri = "https://reverse-whois.whoisxmlapi.com/api/v2"
+        search_string = _get_entity_name
+        api_key =  _get_task_config "whoisxmlapi_api_key"
+    
+        # prepare headers
+        headers = { 'X-Authentication-Token': "#{api_key}" }
+        
+        # perpare search terms
+        search = {"include": [search_string]}
+        #if exclude_term != nil
+        #    search["exclude"] = [exclude_term]
+        #end
+
+        #prepare post body
+        body = {
+            "searchType": "historic",
+            "mode": "purchase",
+            "punycode": true,
+            "basicSearchTerms": search
+        }
+        
+        _log "Searching whoisxmlapi historic and current database."
+        res = http_request :post , uri, nil, headers, body.to_json, true, 60 # setting timeout to 60 seconds since this request takes a while
+
+        if res.return_code == :operation_timedout
+            _log_error "Request timed out after 60 seconds. Try again later."
+            return
+        end
+        
+        # parse response json
+        res_json = JSON.parse(res.body)
+        _log "Received  #{res_json["domainsCount"]} domains. Creating entities."
+
+        # create entities
+        res_json["domainsList"].each do |domain|
+            _create_entity "Domain", {"name" => domain}
+        end
+      end
+    
+    end
+    end
+    end
+    


### PR DESCRIPTION
This PR improves the whoisology task and creates a new task for searching whoisxmlapi. 

For whoisology, the ability to search by UniqueKeyword has been added. Note however that whoisology only works with exact matches, and currently searches the `Organization` field of a whois record for a match with the given UniqueKeyword. 

Whoisxmlapi is much more lenient in the search and finds more results. However, there may be potentially some false positives in the response, something to be vary of.