### PR TITLE
Sonicwall cve 2020 5135

### DIFF
--- a/lib/issues/sonicwall_cve_2020_5135.rb
+++ b/lib/issues/sonicwall_cve_2020_5135.rb
@@ -1,0 +1,32 @@
+module Intrigue
+  module Issue
+  class SonicwallCve20205135 < BaseIssue
+
+    def self.generate(instance_details={})
+      {
+        added: "2020-10-16",
+        name: "sonicwall_cve_2020_5135",
+        pretty_name: "SonicWall VPN Portal Stack-based Buffer Overflow Vulnerability (CVE-2020-5135)",
+        identifiers: [
+          { type: "CVE", name: "CVE-2020-5135" }
+        ],
+        severity: 1,
+        status: "potential",
+        category: "vulnerability",
+        description: "CVE-2020-5135 is a stack-based buffer overflow vulnerability in the VPN Portal of SonicWall’s Network Security Appliance. A remote, unauthenticated attacker could exploit the vulnerability by sending a specially crafted HTTP request with a custom protocol handler to a vulnerable device. At a minimum, successful exploitation would result in a denial of service condition against the exploited device, exhausting its resources. Remote code execution is likely feasible with additional footwork.",
+        remediation: "SonicWall published a patch for this vulnerability. For remediation, update to the latest version of SonicOS firmware.",
+        affected_software: [
+          { :vendor => "SonicWall", :product => "SonicOS"},
+        ],
+        references: [
+          { type: "description", uri: "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2020-0010"}
+          { type: "description", uri: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-5135"},
+          { type: "description", uri: "https://www.tenable.com/blog/cve-2020-5135-critical-sonicwall-vpn-portal-stack-based-buffer-overflow-vulnerability"},
+        ],
+        check: "vuln/sonicwall_cve_2020_5135"
+      }.merge!(instance_details)
+    end
+
+  end
+  end
+  end

--- a/lib/issues/sonicwall_cve_2020_5135.rb
+++ b/lib/issues/sonicwall_cve_2020_5135.rb
@@ -19,7 +19,7 @@ module Intrigue
           { :vendor => "SonicWall", :product => "SonicOS"},
         ],
         references: [
-          { type: "description", uri: "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2020-0010"}
+          { type: "description", uri: "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2020-0010"},
           { type: "description", uri: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-5135"},
           { type: "description", uri: "https://www.tenable.com/blog/cve-2020-5135-critical-sonicwall-vpn-portal-stack-based-buffer-overflow-vulnerability"},
         ],

--- a/lib/tasks/vuln/sonicwall_cve_2020_5135.rb
+++ b/lib/tasks/vuln/sonicwall_cve_2020_5135.rb
@@ -1,0 +1,111 @@
+module Intrigue
+    module Task
+    class SonicwallCve20205135 < BaseTask
+    
+      def self.metadata
+        {
+          :name => "vuln/sonicwall_cve_2020_5135",
+          :pretty_name => "Vuln Check - SonicWall (CVE-2020-5135)",
+          :authors => ["shpendk","jcran"],
+          :identifiers => [{ "cve" =>  "CVE-2020-5135" }],
+          :description => "This task does a version check for CVE-2020-5135 in SonicWall SonicOS",
+          :references => ["https://www.tenable.com/blog/cve-2020-5135-critical-sonicwall-vpn-portal-stack-based-buffer-overflow-vulnerability"],
+          :type => "vuln_check",
+          :passive => false,
+          :allowed_types => ["NetworkService"],
+          :example_entities => [{"type" => "NetworkService", "details" => {"name" => "snmp://intrigue.io:161"}}],
+          :created_types => []
+        }
+      end
+    
+      ## Default method, subclasses must override this
+      def run
+        super
+    
+        # first, ensure we're fingerprinted
+        require_enrichment
+        fingerprint = _get_entity_detail("fingerprint")
+
+        if is_product?(fingerprint, "SonicOS")
+          if is_vulnerable_version?(fingerprint)
+              _create_linked_issue("sonicwall_cve_2020_5135")
+          end
+        end
+      end
+    
+      def is_vulnerable_version?(fingerprint)
+        # affected: SonicOS 6.5.4.7-79n and below, fixed: SonicOS 6.5.4.7-83n
+        # affected: SonicOS 6.5.1.11 and below, fixed: SonicOS 6.5.1.12-1n
+        # affected: SonicOS 6.0.5.3-93o and below, fixed: SonicOS 6.0.5.3-94o
+        # affected: SonicOSv 6.5.4.4-44v-21-794, fixed: SonicOS 6.5.4.v-21s-987
+        # affected: SonicOS 7.0.0.0-1, fixed: SonicOS 7.0.0.0-2 and above
+
+        # get the fingerprints
+        fp = fingerprint.select{|v| v['product'] == "SonicOS" }.first
+        return false unless fp
+
+        # check if fp["version"] is vulnerable
+        
+        # split version to retrieve major/minor versions
+        version_parts = fp["version"].split(".")
+        
+        # check major version
+        case version_parts[0].to_i
+        when 0..5
+            # "Major version is less than 6. We will automatically assume this is vulnerable"
+            _log "Vulnerable!"
+            _create_linked_issue( "sonicwall_cve_2020_5135")
+        when 6
+            # Hardest major version to handle
+            check_vuln_version_six(version_parts)
+        when 7
+            check_vuln_version_seven(version_parts)
+        end
+        
+      end
+
+
+      def check_vuln_version_six(parts)
+        # if 6.5.4.7 -> check after dash
+        # if 6.5.1.11 -> check below 6.5.1.12
+        # if 6.0.5.3-93o -> below 6.0.5.3-94o
+        # if 6.5.4.4-44v-21-794  -> below 6.5.4.4-44v-21-795
+        case parts[1].to_i 
+        when 0 #handling case 6.0: if its 6.0.5.3 -> check after dash and confirm. If below, vuln, if above, not vuln
+            case parts[2].to_i
+            when 0..4 
+                _log "Vulnerable!"
+                create_linked_issue( "sonicwall_cve_2020_5135")
+            when 5
+                case parts[3].to_i
+                when 0..2
+                    _log "Vulnerable!"
+                    create_linked_issue( "sonicwall_cve_2020_5135")
+                when 3
+                    # check after dash
+                    afterdash = parts[4].split("-")
+                    v = afterdash[1].to_i
+                    if v < 94
+                        _log "Vulnerable!"
+                        create_linked_issue( "sonicwall_cve_2020_5135")
+                    else
+                        _log "Not Vulnerable."
+                    end
+                else
+                    _log "Not Vulnerable."
+                end
+            else
+                _log "Not vulnerable."
+            end
+        when 5 # handling various cases when version is 6.5
+            # TODO
+            #case parts[2].to_i
+            #when 
+            #end
+        end
+      end
+    
+    end
+    end
+    end
+    

--- a/lib/tasks/vuln/sonicwall_cve_2020_5135.rb
+++ b/lib/tasks/vuln/sonicwall_cve_2020_5135.rb
@@ -43,8 +43,6 @@ module Intrigue
         # get the fingerprints
         fp = fingerprint.select{|v| v['product'] == "SonicOS" }.first
         return false unless fp
-
-        # check if fp["version"] is vulnerable
         
         # split version to retrieve major/minor versions
         version_parts = fp["version"].split(".")
@@ -57,54 +55,157 @@ module Intrigue
             _create_linked_issue( "sonicwall_cve_2020_5135")
         when 6
             # Hardest major version to handle
-            check_vuln_version_six(version_parts)
+            check_vuln_version_six(version_parts[1],version_parts[2],version_parts[3])
         when 7
-            check_vuln_version_seven(version_parts)
+            check_vuln_version_seven(version_parts[1],version_parts[2],version_parts[3])
+        else
+            _log "Not vulnerable."
         end
         
       end
 
 
-      def check_vuln_version_six(parts)
-        # if 6.5.4.7 -> check after dash
-        # if 6.5.1.11 -> check below 6.5.1.12
-        # if 6.0.5.3-93o -> below 6.0.5.3-94o
-        # if 6.5.4.4-44v-21-794  -> below 6.5.4.4-44v-21-795
-        case parts[1].to_i 
-        when 0 #handling case 6.0: if its 6.0.5.3 -> check after dash and confirm. If below, vuln, if above, not vuln
-            case parts[2].to_i
-            when 0..4 
+      def check_vuln_version_six(major, minor, micro)
+        # for version 6, we have 4 cases
+        # when 6.0 -> check further
+        # when 6.1 - 6.4 -> assume vulnerable
+        # when 6.5 -> check further
+        # else not vulnerable
+
+        # run cases
+        case major.to_i 
+            when 0 #handling case 6.0: if its 6.0.5.3 -> check after dash and confirm. If below, vuln, if above, not vuln
+                check_vuln_version_six_zero(minor, micro)
+            when 1..4
                 _log "Vulnerable!"
-                create_linked_issue( "sonicwall_cve_2020_5135")
-            when 5
-                case parts[3].to_i
-                when 0..2
+                _create_linked_issue( "sonicwall_cve_2020_5135")
+            when 5 
+                # handling various cases when version is 6.5
+                check_vuln_version_six_five(minor, micro)
+            else
+                _log "Not Vulnerable."
+        end
+    end
+
+
+      def check_vuln_version_seven(major, minor, micro)
+        # version 7.0.0.0-1 and below are vulnerable
+        dash = micro.split("-")
+        before_dash = dash[0]
+        after_dash = dash[1]
+
+        
+        if major.to_i == 0 and minor.to_i == 0 and before_dash.to_i == 0
+            v = after_dash.to_i
+            if v < 2
+                _log "Vulnerable!"
+                _create_linked_issue( "sonicwall_cve_2020_5135")
+            else
+                _log "Not Vulnerable."
+            end
+        else
+            _log "Not Vulnerable."
+        end
+    end
+
+    def check_vuln_version_six_zero(minor, micro)
+        # when version is 6.0.something, we have the following cases
+        # 0-4 are vulnerable
+        # 5.0 - 5.2 vulnerable
+        # 5.3 must check micro part
+        # else not vulnerable
+
+        # split micro , since it may contain dash
+        dash = micro.split("-")
+        before_dash = dash[0]
+        after_dash = dash[1]
+        
+        case minor.to_i
+        when 0..4 
+            _log "Vulnerable!"
+            _create_linked_issue( "sonicwall_cve_2020_5135")
+        when 5
+            case before_dash.to_i
+            when 0..2
+                _log "Vulnerable!"
+                _create_linked_issue( "sonicwall_cve_2020_5135")
+            when 3
+                v = after_dash.to_i
+                if v < 94
                     _log "Vulnerable!"
-                    create_linked_issue( "sonicwall_cve_2020_5135")
-                when 3
-                    # check after dash
-                    afterdash = parts[4].split("-")
-                    v = afterdash[1].to_i
-                    if v < 94
-                        _log "Vulnerable!"
-                        create_linked_issue( "sonicwall_cve_2020_5135")
-                    else
-                        _log "Not Vulnerable."
-                    end
+                    _create_linked_issue( "sonicwall_cve_2020_5135")
                 else
                     _log "Not Vulnerable."
                 end
             else
-                _log "Not vulnerable."
+                _log "Not Vulnerable."
             end
-        when 5 # handling various cases when version is 6.5
-            # TODO
-            #case parts[2].to_i
-            #when 
-            #end
+        else
+            _log "Not vulnerable."
         end
-      end
+    end
+
+    def check_vuln_version_six_five(minor, micro)
+        # when version is 6.5.something, we have the following cases
+        # 0 -> vulnerable
+        # 1 -> check micro
+        # 2-3 -> vulnerable
+        # 4 -> check micro
+        # else not vulnerable
+
+        # split micro , since it may contain dash
+        dash = micro.split("-")
+        before_dash = dash[0]
+        after_dash = dash[1]
+
+        case minor.to_i
+        when 0
+            _log "Vulnerable!"
+            _create_linked_issue( "sonicwall_cve_2020_5135")
+        when 1
+            if before_dash.to_i < 12
+                _log "Vulnerable!"
+                _create_linked_issue( "sonicwall_cve_2020_5135")
+            else
+                _log "Not Vulnerable."
+            end 
+        when 2..3
+            _log "Vulnerable!"
+            _create_linked_issue( "sonicwall_cve_2020_5135")
+        when 4
+            case before_dash.to_i
+            when 0..3
+                _log "Vulnerable!"
+                _create_linked_issue( "sonicwall_cve_2020_5135")
+            when 4
+                v = after_dash.to_i
+                if v < 44
+                    _log "Vulnerable!"
+                    _create_linked_issue( "sonicwall_cve_2020_5135")
+                else
+                    _log "Not Vulnerable."
+                end
+            when 5..6
+                _log "Vulnerable!"
+                    _create_linked_issue( "sonicwall_cve_2020_5135")
+            when 7
+                v = after_dash.to_i
+                if v < 83
+                    _log "Vulnerable!"
+                    _create_linked_issue( "sonicwall_cve_2020_5135")
+                else
+                    _log "Not Vulnerable."
+                end
+            else
+                _log "Not Vulnerable."
+            end
+        else 
+            _log "Not Vulnerable."
+        end
     
+    end
+
+
     end
     end
     end


### PR DESCRIPTION
This is the check and issue for SonicWall CVE-2020-5135. This is subject to merging the following PR in ident: https://github.com/intrigueio/intrigue-ident/pull/63

The check itself is just a version comparison, however, SonicWall has complex versioning. According to their [security advisory](https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2020-0010), different release versions are vulnerable if below a certain value. I did my best to figure this out and ensure there are no false positives, but I cannot guarantee. Also, the way I'm comparing versions is ugly and there's probably better ways to do it which I'm not aware of.