### PR TITLE
issue and check for loginizer CVE-2020-27615

### DIFF
--- a/lib/issues/wordpress_loginizer_cve_2020_27615.rb
+++ b/lib/issues/wordpress_loginizer_cve_2020_27615.rb
@@ -1,0 +1,26 @@
+module Intrigue
+    module Issue
+    class WordpressUserInfoLeak < BaseIssue
+    
+      def self.generate(instance_details={})
+        {
+          added: "2020-22-10",
+          name: "wordpress_loginizer_cve_2020_27615",
+          pretty_name: "Wordpress Loginizer Plugin SQL Injection - CVE-2020-27615",
+          severity: 1,
+          category: "vulnerability",
+          status: "confirmed",
+          description: "This Wordpress site has a vulnerable version of Loginizer plugin.",
+          remediation: "Update to Loginizer 1.6.4 or later",
+          affected_software: [{ :vendor => "Wordpress", :product => "Loginizer" }],
+          references: [ # types: description, remediation, detection_rule, exploit, threat_intel
+            { type: "description", uri: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27615" },
+            {type: "description", uri: "https://wpdeeply.com/loginizer-before-1-6-4-sqli-injection/"}
+          ], 
+          check: "vuln/wordpress_loginizer_cve_2020_27615"
+        }.merge!(instance_details)
+      end
+    
+    end
+    end
+    end

--- a/lib/tasks/vuln/wordpress_loginizer_cve_2020_27615.rb
+++ b/lib/tasks/vuln/wordpress_loginizer_cve_2020_27615.rb
@@ -1,0 +1,59 @@
+module Intrigue
+    module Task
+    class LoginizerCVE202027615 < BaseTask
+    
+      def self.metadata
+        {
+          :name => "vuln/wordpress_loginizer_cve_2020_27615",
+          :pretty_name => "Vuln Check - Wordpress Loginizer Plugin SQL Injection - (CVE-2020-27615)",
+          :authors => ["shpendk"],
+          :identifiers => [{ "cve" =>  "CVE-2020-27615" }],
+          :description => "This task does a version check for Loginizer SQL injection vulnerability (CVE-2020-27615)",
+          :references => ["https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27615"],
+          :type => "vuln_check",
+          :passive => false,
+          :allowed_types => ["Uri"],
+          :example_entities => [{"type" => "Uri", "details" => {"name" => "https://intrigue.io"}}],
+          :created_types => []
+        }
+      end
+    
+      ## Default method, subclasses must override this
+      def run
+        super
+    
+        require_enrichment
+    
+        # check our fingerprints for a version
+        our_version = nil
+        fp = _get_entity_detail("fingerprint")
+        fp.each do |f|
+          if f["vendor"] == "Wordpress" && f["product"] == "Loginizer"
+            our_version = f["version"]
+            break
+          end
+        end
+    
+        if our_version
+          _log "Got version: #{our_version}"
+        else
+          _log_error "Unable to get version, failing."
+          return
+        end
+    
+        # check the version to see if its vulnerable.
+        # versions smaller than 1.6.4 are vulnerable as per https://wpdeeply.com/loginizer-before-1-6-4-sqli-injection/
+        _log "Checking version against known vulnerable versions"
+    
+        if ::Versionomy.parse(our_version) < ::Versionomy.parse("1.6.4")
+          _log_good "Vulnerable!"
+          _create_linked_issue "wordpress_loginizer_cve_2020_27615"
+        else
+          _log "Not vulnerable!"
+        end
+      end
+    
+    end
+    end
+    end
+    


### PR DESCRIPTION
This PR contains the issue and check for Wordpress plugin: Loginizer (CVE-2020-27615). Requires the fingerprint to be approved in this PR: https://github.com/intrigueio/intrigue-ident/pull/65