### PR TITLE
add subfinder as a task, and adjust golang deps

### DIFF
--- a/lib/tasks/subfinder.rb
+++ b/lib/tasks/subfinder.rb
@@ -1,0 +1,52 @@
+module Intrigue
+  module Task
+  class Subfinder < BaseTask
+  
+    def self.metadata
+      {
+        :name => "subfinder",
+        :pretty_name => "Subfinder",
+        :authors => ["jcran", "projectdiscovery"],
+        :description => "This task uses subfinder to find domains.",
+        :references => [],
+        :type => "discovery",
+        :passive => false,
+        :allowed_types => ["Domain"],
+        :example_entities => [{"type" => "Domain", "details" => {"name" => "intrigue.io"}}],
+        :allowed_options => [],
+        :created_types => [ "DnsRecord", "IpAddress" ]
+      }
+    end
+  
+    ## Default method, subclasses must override this
+    def run
+      super
+
+      domain = _get_entity_name
+
+      command = "subfinder -oJ -silent -d #{domain}"
+      _log "Running: #{command}"
+      
+      out = _unsafe_system(command)
+
+      # handle the no-result case
+      unless out 
+        _log "No output! returning!"
+        return
+      end
+
+      # otherwise, create network services 
+      lines = out.split("\n")
+      _log "Got #{lines.count} subdomains!"
+      lines.each do |l|
+        j = JSON.parse(l)
+        subdomain = j["host"]
+        create_dns_entity_from_string subdomain # { "upstream_source" => j["source"] }
+      end
+
+    end
+  
+  end
+  end
+  end
+  

--- a/util/bootstrap-standalone.sh
+++ b/util/bootstrap-standalone.sh
@@ -164,15 +164,17 @@ echo export PATH=$PATH:$GOROOT/bin:$GOPATH/bin >> ~/.bash_profile
 
 # ffuf
 echo "[+] Getting Ffuf... "
-go get github.com/intrigueio/ffuf
+GO111MODULE=on go get -u -v github.com/ffuf/ffuf
 
 # gitrob
 echo "[+] Getting Gitrob... "
-go get github.com/intrigueio/gitrob
+wget https://github.com/michenriksen/gitrob/releases/download/v2.0.0-beta/gitrob_linux_amd64_2.0.0-beta.zip
+unzip gitrob_linux_amd64_2.0.0-beta.zip
+sudo mv gitrob /usr/local/bin
 
 # gobuster
 echo "[+] Getting Gobuster... "
-go get github.com/intrigueio/gobuster.git
+go get github.com/OJ/gobuster
 
 # ghostcat
 echo "[+] Getting Ghostcat Vuln... "
@@ -203,6 +205,9 @@ if [ ! -f /usr/bin/rdpscan ]; then
   cd ..
   rm -rf rdpscan
 fi
+
+# subfinder 
+GO111MODULE=on go get -u -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder
 
 ### Install latest tika
 echo "[+] Installing Apache Tika from public.intrigue.io"


### PR DESCRIPTION
Initial subfinder integration
 - adds subfinder as an external dependency
 - adds task to run subfinder, given a domain
 - adjusts golang deps to pull direct from the origin repo
 - adds static dep for gitrob

Example usage:

![image](https://user-images.githubusercontent.com/76854/97648969-1cd81480-1a24-11eb-86e1-67958b00c22e.png)
