### PR TITLE
Make grouped entities an optional view

### DIFF
--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -312,14 +312,14 @@ module Model
         <label for="entity_type" class="col-xs-4 control-label">Entity Type</label>
         <div class="col-xs-8">
           <select class="form-control input-sm" id="entity_type" name="entity_type">
-            <option> #{self.type_string} </option>
+            <option> #{URI.escape self.type_string} </option>
           </select>
         </div>
       </div>
       <div class="form-group">
         <label for="attrib_name" class="col-xs-4 control-label">Entity Name</label>
         <div class="col-xs-8">
-          <input type="text" class="form-control input-sm" id="attrib_name" name="attrib_name" value="#{self.name}">
+          <input type="text" class="form-control input-sm" id="attrib_name" name="attrib_name" value="#{URI.escape self.name}">
         </div>
       </div>}
     end

--- a/app/models/logger.rb
+++ b/app/models/logger.rb
@@ -54,10 +54,7 @@ module Model
       # if method is set to none, don't log anything
       return if location == "none"
 
-      encoded_out = message.encode("UTF-8", {
-                              :undef => :replace,
-                              :invalid => :replace,
-                              :replace => "?" })
+      encoded_out = message.encode("UTF-8", undef: :replace, invalid: :replace, replace: "?")
 
       if location == "database"
         begin

--- a/app/routes/entities.rb
+++ b/app/routes/entities.rb
@@ -7,21 +7,25 @@ class CoreApp < Sinatra::Base
     params[:include_hidden] == "on" ? @include_hidden = true : @include_hidden = false
     params[:include_unscoped] == "on" ? @include_unscoped = true : @include_unscoped = false
     params[:only_enriched] == "on" ? @only_enriched = true : @only_enriched = false
+    params[:grouped_entities] == "on" ? @grouped_entities = true : @grouped_entities = false
+
     (params[:page] != "" && params[:page].to_i > 0) ? @page = params[:page].to_i : @page = 1
     (params[:count] != "" && params[:count].to_i > 0) ? @count = params[:count].to_i : @count = 100
 
-    selected_entities = Intrigue::Core::Model::Entity.scope_by_project(@project_name)
-    selected_entities = selected_entities.where(:type => @entity_types) if @entity_types
-    selected_entities = _tokenized_search(@search_string, selected_entities) if @search_string
+    @selected_entities = Intrigue::Core::Model::Entity.scope_by_project(@project_name)
+    @selected_entities = @selected_entities.where(:type => @entity_types) if @entity_types
+    @selected_entities = _tokenized_search(@search_string, @selected_entities) if @search_string
+    @selected_entities = @selected_entities.where(:enriched => true) if  @only_enriched
 
-    selected_entities = selected_entities.where(:enriched => true) if  @only_enriched
+    # create a calculated url with our parameters
+    @calculated_url = "/#{h @project_name}/entities?search_string=#{h @search_string}&include_hidden=#{@include_hidden ? 'on' : 'off'}&include_unscoped=#{@include_unscoped ? 'on' : 'off'}&grouped_entities=#{@grouped_entities ? 'on' : 'off'}&#{@entity_types.map{|x| "entity_types[]=#{h x}" }.join("&") if @entity_types}"
 
     if params[:export] == "csv"
 
       content_type 'application/csv'
       attachment "#{@project_name}.csv"
       result = ""
-      selected_entities.paged_each(:rows_per_fetch => 300){ |e| result << "#{e.export_csv}\n" }
+      @selected_entities.paged_each(:rows_per_fetch => 300){ |e| result << "#{e.export_csv}\n" }
       return result
 
     elsif params[:export] == "json"
@@ -29,13 +33,13 @@ class CoreApp < Sinatra::Base
       content_type 'application/json'
       attachment "#{@project_name}.json"
       result = []
-      selected_entities.paged_each(:rows_per_fetch => 300){ |e| result << "#{e.export_json}" }
+      @selected_entities.paged_each(:rows_per_fetch => 300){ |e| result << "#{e.export_json}" }
       return result.to_json
 
     else # normal page
 
-     selected_entities = selected_entities.paginate(@page, @count).order(:name)
-     alias_group_ids = selected_entities.select_map(:alias_group_id).uniq
+     @selected_entities = @selected_entities.paginate(@page, @count).order(:name)
+     alias_group_ids = @selected_entities.select_map(:alias_group_id).uniq
      @alias_groups = Intrigue::Core::Model::AliasGroup.where({:id => alias_group_ids })
      erb :'entities/index'
 

--- a/app/views/_task_runner.erb
+++ b/app/views/_task_runner.erb
@@ -1,6 +1,6 @@
 
 <div class="col-sm-7">
-<form class="form-horizontal" id="task_runner" enctype="multipart/form-data" target="_self" method="post" action="/<%=h @project_name%>/interactive/single">
+<form class="form-horizontal" id="task_runner" enctype="multipart/form-data" target="_self" method="post" action="/<%= h @project_name%>/interactive/single">
   <div class="form-group">
     <!-- <select name="task" id="task_name"> -->
     <label for="task_name" class="col-xs-4 control-label">Task</label>
@@ -16,13 +16,13 @@
         %>
 
         <!-- set up the task in an option box, default to create_entity -->
-        <option value="<%= task_class.metadata[:name] %>"
+        <option value="<%= h task_class.metadata[:name] %>"
           <% if @task_result %>
             <%= "selected='selected'" if @task_result.task_name == task_class.metadata[:name] %>
           <% else %>
             <%= "selected='selected'" if task_class.metadata[:name] == "create_entity" %>
           <% end %>
-          ><%= task_class.metadata[:pretty_name] %>
+          ><%= h task_class.metadata[:pretty_name] %>
         </option>
 
       <% end %>
@@ -60,9 +60,9 @@
           <!-- iterate through stategies -->
           <% Intrigue::MachineFactory.list.each do |machine_class| %>
            <% next unless machine_class.metadata[:user_selectable] %>
-            <option value="<%= machine_class.metadata[:name] %>"
+            <option value="<%= h machine_class.metadata[:name] %>"
               <%= "selected='selected'" if machine_class.metadata[:name] == "org_asset_discovery_active" %> >
-              <%= machine_class.metadata[:pretty_name] %>
+              <%= h machine_class.metadata[:pretty_name] %>
             </option>
           <% end %>
         </select>

--- a/app/views/entities/_search.erb
+++ b/app/views/entities/_search.erb
@@ -17,6 +17,7 @@
     <input id="include_unscoped" name="include_hidden" type="checkbox" <%='checked' if @include_hidden %> > Show Hidden <br/>
     <input id="include_unscoped" name="include_unscoped" type="checkbox" <%='checked' if @include_unscoped %> > Show Unscoped <br/>
     <input id="only_enriched" name="only_enriched" type="checkbox"> Only Enriched <br/>
+    <input id="grouped_entities" name="grouped_entities" type="checkbox" <%='checked' if @grouped_entities %> > Group View <br/>
 
     <input class="btn btn-primary" type="submit" value="Search">
   </form>

--- a/app/views/entities/index.erb
+++ b/app/views/entities/index.erb
@@ -1,103 +1,89 @@
 <script language="javascript" type="text/javascript">
-function delete_entity(id)
-{
-  var check = confirm('Are you sure?');
-  if (check == true) {
-      document.entity_delete_form.entity.value = id;
-      document.entity_delete_form.action = "/<%=h @project_name%>/meta_entities/" + id + "/delete"
-      document.entity_delete_form.submit();
-      return true;
+  function delete_entity(id)
+  {
+    var check = confirm('Are you sure?');
+    if (check == true) {
+        document.entity_delete_form.entity.value = id;
+        document.entity_delete_form.action = "/<%=h @project_name%>/meta_entities/" + id + "/delete"
+        document.entity_delete_form.submit();
+        return true;
+    }
+    else {
+        return false;
+    }
   }
-  else {
-      return false;
-  }
-}
-</script>
-
-<div class="col-sm-2">
-  <%= erb :'/entities/_search', :layout => false %>
-</div>
-<div class="col-sm-10">
-  <a href="/<%=h @project_name%>/entities?search_string=<%=@search_string%>&include_hidden=<%= @include_hidden ? 'on' : 'off' %>&include_unscoped=<%=@include_unscoped ? 'on' : 'off'%>&correlate=on&page=<%=@page-1%>&<%=@entity_types.map{|x| "entity_types[]=#{x}" }.join("&") if @entity_types %>">previous</a>
-  <a href="/<%=h @project_name%>/entities?search_string=<%=@search_string%>&include_hidden=<%= @include_hidden ? 'on' : 'off' %>&include_unscoped=<%=@include_unscoped ? 'on' : 'off'%>&correlate=on&page=<%=@page+1%>&<%=@entity_types.map{|x| "entity_types[]=#{x}" }.join("&") if @entity_types %>">next</a>
+  </script>
+  
+  <div class="col-sm-2">
+    <%= erb :'/entities/_search', :layout => false %>
+  </div>
+  <div class="col-sm-10">
+    <a href="<%=@calculated_url%>?page=<%=@page-1%>">previous</a>
+    <a href="<%=@calculated_url%>?page=<%=@page+1%>">next</a>
     <%= "Page: #{@page}" %> / <%= "Viewing Results: #{@count * (@page-1)} .. #{@count * @page-1}" %>
-
-  <script type="text/javascript" src="/js/sorttable.js"></script>
-  <style>
-  /* Sortable tables */
-  table.sortable {
-    width: 100%;
-    border: 0;
-    table-layout:fixed;
-    word-wrap:break-word;
-    border-collapse:collapse;
-  }
-
-  table.sortable thead {
-      background-color:#eee;
-      color:#666666;
-      font-weight: bold;
-      cursor: default;
-  }
-  </style>
-  <p></p>
-  <table class="sortable" border="1" width=100%>
-    <colgroup>
-      <col style="width:40%">
-      <col style="width:60%">
-    </colgroup>
-    <tbody>
-      <tr><th>name</th><th>details</th></tr>
-      <% @alias_groups.each do |group| %>
-        <% next if group.entities.empty? %>
-        <tr>
-          <td>
-            <ul>
-          <% group.entities.each do |e| %>
-            <%
-
-              # skip hidden unless we allow it
-              unless @include_hidden
-                next if e.hidden
-              end
-
-              # skip unscoped unless we allow it
-              unless @include_unscoped
-               next unless e.scoped
-              end
-
-            %>
-                <li>[<a href="/<%=h @project_name%>/entities/<%=e.id%>"> <%= h e %> </a>]</li>
+  
+    <script type="text/javascript" src="/js/sorttable.js"></script>
+    <style>
+    /* Sortable tables */
+    table.sortable {
+      width: 100%;
+      border: 0;
+      table-layout:fixed;
+      word-wrap:break-word;
+      border-collapse:collapse;
+    }
+  
+    table.sortable thead {
+        background-color:#eee;
+        color:#666666;
+        font-weight: bold;
+        cursor: default;
+    }
+    </style>
+    <p></p>
+    <table class="sortable" border="1" width=100%>
+      <colgroup>
+        <col style="width:40%">
+        <col style="width:60%">
+      </colgroup>
+      <tbody>
+        <tr><th>name</th><th>details</th></tr>
+        <% if @grouped_entities %>
+          <% @alias_groups.each do |group| %>
+            <% grouped_entities = group.entities %>
+            <% grouped_entities = grouped_entities.reject{|x| !x.scoped } unless @include_unscoped %>
+            <% grouped_entities = grouped_entities.reject{|x| x.hidden } unless @include_hidden %>
+            <% next if grouped_entities.empty? %>
+            <tr>
+              <td>
+                <ul>
+                <% grouped_entities.each do |e| %>
+                  <li>[<a href="/<%=h @project_name%>/entities/<%=e.id%>"> <%= h e %> </a>]</li>
+                <% end %>
+                  </ul>
+                </td>
+                <td>
+                  <ul>
+                <% grouped_entities.each do |e| %>
+                  <li><a href="/<%=h @project_name%>/entities/<%=e.id%>"> <%= h e.detail_string %> </a></li>
+                <% end %>
+                </ul>
+              </td>
+            </tr>
           <% end %>
-              </ul>
-            </td>
-            <td>
-              <ul>
-          <% group.entities.each do |e| %>
-            <%
-              
-              # skip hidden unless we allow it
-              unless @include_hidden
-                next if e.hidden
-              end
-
-              # skip hidden unless we allow it
-              unless @include_unscoped
-               next unless e.scoped
-              end
-
-            %>
-              <li><a href="/<%=h @project_name%>/entities/<%=e.id%>"> <%= h e.detail_string %> </a></li>
+        <% else %>
+            <% @selected_entities.each do |e| %>
+            <tr>
+              <td><a href="/<%=h @project_name%>/entities/<%=e.id%>"> <%= h e %> </a></td>
+              <td><%= h e.detail_string %></td>
+            </tr>
+            <% end %> 
         <% end %>
-            </ul>
-          </td>
-        </tr>
-      <% end %>
-
-    </tbody>
-  </table>
-  <a href="/<%=h @project_name%>/entities?search_string=<%=@search_string%>&include_hidden=<%= @include_hidden ? 'on' : 'off' %>&include_unscoped=<%=@include_unscoped ? 'on' : 'off'%>&correlate=on&page=<%=@page-1%>&<%=@entity_types.map{|x| "entity_types[]=#{x}" }.join("&") if @entity_types %>">previous</a>
-  <a href="/<%=h @project_name%>/entities?search_string=<%=@search_string%>&include_hidden=<%= @include_hidden ? 'on' : 'off' %>&include_unscoped=<%=@include_unscoped ? 'on' : 'off'%>&correlate=on&page=<%=@page+1%>&<%=@entity_types.map{|x| "entity_types[]=#{x}" }.join("&") if @entity_types %>">next</a>
-  <br><br><br>
-<form name="entity_delete_form" method="get"><input type="hidden" id="entity" name="entity"/></form>
-</div>
+      </tbody>
+    </table>
+    <a href="<%=@calculated_url%>?page=<%=@page-1%>">previous</a>
+    <a href="<%=@calculated_url%>?page=<%=@page+1%>">next</a>
+    <br><br><br>
+  <form name="entity_delete_form" method="get"><input type="hidden" id="entity" name="entity"/></form>
+  </div>
+  


### PR DESCRIPTION
Grouped entities often cause confusion at first, so this change makes them an optional search parameter. it also cleans up the output so there are not empty lines in the display. 

Updated entities page, with a search applied: 
![image](https://user-images.githubusercontent.com/76854/97781292-514ced00-1b58-11eb-9a0b-5b073b5164fe.png)


