### PR TITLE
Change product name to match cpe

### DIFF
--- a/lib/issues/oracle_weblogic_vulnerable_paths.rb
+++ b/lib/issues/oracle_weblogic_vulnerable_paths.rb
@@ -13,7 +13,7 @@ class OracleWeblogicVulnerablePaths < BaseIssue
       description: "This server is exposing paths known to be suceptable to many vulnerabilities/",
       remediation: "Block access to these paths.",
       affected_software: [
-        { :vendor => "Oracle", :product => "Weblogic" }
+        { :vendor => "Oracle", :product => "Weblogic Server" }
       ],
       references: [],
       check: "uri_brute_focused_content"


### PR DESCRIPTION
Im suggesting to change the product name to `Weblogic Server`, since this is the format in CPE as well (see [here](https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Aoracle%3Aweblogic_server)). 