### PR TITLE
Remove no-longer-supported puma directive

### DIFF
--- a/config/puma.rb.default
+++ b/config/puma.rb.default
@@ -36,7 +36,7 @@ environment ENV.fetch('INTRIGUE_ENV', 'development')
 #
 # The default is "true".
 #
-daemonize false
+# daemonize false
 
 # Store the pid of the server in the file at "path".
 #


### PR DESCRIPTION
does what it says on the tin ... removes the 'daemonize' directive. No longer needed as we handle this with foreman / god in production today.