### PR TITLE
bump to ruby 2.7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.6.5'
+ruby '2.7.2'
 
 # core
 gem 'sinatra'                 #'~> 2.0.1'
@@ -97,5 +97,5 @@ gem "sentry-raven"            # Error tracking (disabled by default)
 
 
 ### Private checks and modules ... uncomment if needed
-##gem 'intrigue-ident-private',        :path => "~/intrigue-ident-private"
-##gem 'intrigue-core-private',         :path => "~/intrigue-core-private"
+gem 'intrigue-ident-private',        :path => "~/intrigue-ident-private"
+gem 'intrigue-core-private',         :path => "~/intrigue-core-private"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,10 +33,10 @@ GIT
 
 GIT
   remote: https://github.com/intrigueio/intrigue-ident.git
-  revision: a70c3184dd698b9cdd4da3ee312147a8ef582fa7
+  revision: c5b4a7e986e8475fc44985c1d2bdbdc2901ec021
   branch: main
   specs:
-    intrigue-ident (3.1.6)
+    intrigue-ident (3.1.7)
       dnsruby
       murmurhash3
       recog-intrigue
@@ -106,6 +106,16 @@ GIT
     whoisology (0.1.0)
 
 PATH
+  remote: ../../../../intrigue-core-private
+  specs:
+    intrigue-core-private (0.8.7)
+
+PATH
+  remote: ../../../../intrigue-ident-private
+  specs:
+    intrigue-ident-private (3.1.2)
+
+PATH
   remote: api_client
   specs:
     intrigue_api_client (1.6.0)
@@ -123,27 +133,27 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    async (1.26.2)
-      console (~> 1.0)
+    async (1.27.0)
+      console (~> 1.10)
       nio4r (~> 2.3)
       timers (~> 4.1)
-    async-http (0.52.5)
+    async-http (0.53.1)
       async (~> 1.25)
       async-io (~> 1.28)
       async-pool (~> 0.2)
-      protocol-http (~> 0.20.0)
+      protocol-http (~> 0.21.0)
       protocol-http1 (~> 0.13.0)
       protocol-http2 (~> 0.14.0)
     async-io (1.30.1)
       async (~> 1.14)
-    async-pool (0.3.2)
+    async-pool (0.3.3)
       async (~> 1.25)
     async-rest (0.10.1)
       async-http (~> 0.42)
       protocol-http (~> 0.7)
     aws-eventstream (1.1.0)
-    aws-partitions (1.388.0)
-    aws-sdk-core (3.109.1)
+    aws-partitions (1.393.0)
+    aws-sdk-core (3.109.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -154,7 +164,7 @@ GEM
     aws-sdk-route53 (1.44.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.83.1)
+    aws-sdk-s3 (1.84.1)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -238,7 +248,7 @@ GEM
     foreman (0.87.2)
     formatador (0.2.5)
     god (0.13.7)
-    google-api-client (0.47.0)
+    google-api-client (0.49.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.9)
       httpclient (>= 2.8.1, < 3.0)
@@ -297,7 +307,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0512)
+    mime-types-data (3.2020.1104)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -320,7 +330,7 @@ GEM
     pg (1.2.3)
     power_assert (1.2.0)
     protocol-hpack (1.4.2)
-    protocol-http (0.20.1)
+    protocol-http (0.21.0)
     protocol-http1 (0.13.1)
       protocol-http (~> 0.19)
     protocol-http2 (0.14.1)
@@ -431,7 +441,7 @@ GEM
     towerdata_api (1.3.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.7)
+    tzinfo (1.2.8)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unf (0.1.4)
@@ -478,7 +488,9 @@ DEPENDENCIES
   googleajax
   googleauth
   iconv
+  intrigue-core-private!
   intrigue-ident!
+  intrigue-ident-private!
   intrigue_api_client!
   ip_ranger!
   ipaddr
@@ -528,7 +540,7 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
A few warnings we'll want to clean up, generally seems like things are working fine. let's do it ahead of the v0.8.0. Also note that this bumps the gems to latest as well. 