### PR TITLE
Nuclei integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem 'pry-byebug'              # Debugging
 gem 'yard'
 gem "sentry-raven"            # Error tracking (disabled by default)
 
-
-### Private checks and modules ... uncomment if needed
-##gem 'intrigue-ident-private',        :path => "~/intrigue-ident-private"
-##gem 'intrigue-core-private',         :path => "~/intrigue-core-private"
+### Private checks and modules ...  uncomment if running in (dev) hosted configuration
+#gem 'intrigue-ident-private',        :path => "~/intrigue-ident-private"
+#gem 'intrigue-core-private',         :path => "~/intrigue-core-private"
+#gem 'ruclei',                        :path => "~/ruclei"

--- a/lib/all.rb
+++ b/lib/all.rb
@@ -151,3 +151,12 @@ rescue LoadError => e
   # unable to load gem, presumably unavailable
 end
 
+###
+# load in ruclei if available
+###
+begin
+  require 'ruclei'
+rescue LoadError => e 
+  # unable to load gem, presumably unavailable
+end
+

--- a/lib/intrigue-issues.rb
+++ b/lib/intrigue-issues.rb
@@ -64,6 +64,21 @@ class IssueFactory
   mapped_issues.flatten.select{|x| x[:vendor] == vendor && x[:product] == product}.map{|x| x[:check] }.uniq.compact
   end
 
+  #
+  # Find issue based on check value
+  #
+  def self.find_issue_by_check(check)
+
+    self.issues.each do |h| 
+      # generate the instances
+      hi = h.generate({});
+      if hi[:check] == check
+        return hi
+      end
+    end
+    nil
+  end
+
 
   #
   # Check to see if this handler exists (check by type)

--- a/lib/system/helpers.rb
+++ b/lib/system/helpers.rb
@@ -16,6 +16,13 @@ module System
     def start_task(queue, project, existing_scan_result_id, task_name, entity, depth,
           options=[], handlers=[], machine_name="external_discovery_light_active", auto_enrich=true, auto_scope=false)
 
+      # check name of task, if its a nuclei task => use nuclei runner and pass template as option
+      if task_name =~ /^nuclei\:.*/
+        template_name = task_name.split(":")[1]
+        task_name = "nuclei_runner"
+        options = [{name: "template", regex: "filename", value: template_name}]
+      end
+      
       # Create the task result, and associate our entity and options
       logger = Intrigue::Core::Model::Logger.create(:project_id => project.id)
       task_result = Intrigue::Core::Model::TaskResult.create({

--- a/lib/system/helpers.rb
+++ b/lib/system/helpers.rb
@@ -20,7 +20,7 @@ module System
       if task_name =~ /^nuclei\:.*/
         template_name = task_name.split(":")[1]
         task_name = "nuclei_runner"
-        options = [{name: "template", regex: "filename", value: template_name}]
+        options = [{name: "template", regex: "alpha_numeric_list", value: template_name}]
       end
       
       # Create the task result, and associate our entity and options


### PR DESCRIPTION
The following changes were made to support integration of nuclei:
1. In `lib/system/helpers.rb` , the function `start_task` was adjusted to allow specifying a nuclei template.
2. In `lib/intrigue-issues.rb`, a function to retrieve an issue based on the given check is implemented.
3. Added ruclei to gemfile.
4. Loaded ruclei in `/lib/all.rb`