### PR TITLE
Two bug fixes for inference checks

### DIFF
--- a/lib/intrigue-issues.rb
+++ b/lib/intrigue-issues.rb
@@ -36,7 +36,7 @@ class IssueFactory
     self.issues.each do |h| 
       # generate the instances
       issue_instance = h.generate({})
-      return issue_instance[:name] if issue_instance["check"] =~ /inference:#{cve_id}/i      
+      return issue_instance[:name] if issue_instance[:check] =~ /inference:#{cve_id}/i      
     end
   nil
   end

--- a/lib/tasks/helpers/ident.rb
+++ b/lib/tasks/helpers/ident.rb
@@ -12,7 +12,7 @@ module Ident
       next unless fp["vulns"]
       fp["vulns"].each do |vuln|
         # get and create the issue here 
-        issue_name = Intrigue::Issue::IssueFactory.get_issue_by_inferred_cve(vuln["cve"])
+        issue_name = Intrigue::Issue::IssueFactory.get_issue_by_inferred_cve(vuln[:cve])
         next unless issue_name
 
         # if we're here, go ahead and create the linked issue!
@@ -45,8 +45,11 @@ module Ident
     #
     all_checks.flatten.compact.uniq.each do |task|
 
+      # skip inference checks, they are handled in fingerprint_to_inference_issues
+      if task =~ /^inference:.*/
+        next
       # handle nuclei-enabled checks (ruclei)
-      if task =~ /^nuclei:.*/
+      elsif task =~ /^nuclei:.*/
         nuclei_template = t.split(":").last
         task = "nuclei_runner"
         task_options = [{name: "template", regex: "alpha_numeric_list", value: nuclei_template}]


### PR DESCRIPTION
Some of the hash names needed correction, and there was a bug where it would try to run an "inference" task.

I've tested this locally and it works as expected. If a CVE is found through inference and we have a matching issue with `check: "inference:CVE-ID-HERE"`, the issue will be raised automatically.