### PR TITLE
fixes two bugs that were crashing enrich uri

### DIFF
--- a/lib/initialize/string.rb
+++ b/lib/initialize/string.rb
@@ -4,7 +4,7 @@ class String
   
   def to_bool
     return true   if self =~ (/(true|t|yes|y|1)$/i) || self == true
-    return false  if self =~ (/(false|f|no|n|0)$/i) || self == false || self.blank?
+    return false  if self =~ (/(false|f|no|n|0)$/i) || self == false || self.empty?
     raise ArgumentError.new("invalid value for Boolean: \"#{self}\"")
   end
 

--- a/lib/tasks/helpers/vulndb.rb
+++ b/lib/tasks/helpers/vulndb.rb
@@ -48,6 +48,7 @@ module VulnDb
 
   class Cpe
     include Intrigue::Task::Web
+    require 'versionomy'
 
     def initialize(cpe_string)
       


### PR DESCRIPTION
This is a somewhat urgent PR. The call to vulndb is failing (because it can't find versionomy) and as a result, all of enrich uri crashes. This may have implications for other tasks.

I am not sure that requiring versionomy [here](https://github.com/intrigueio/intrigue-core/commit/951f154b4445f6af373550b1ac972df2df812389#diff-42ed233d8c0997ef5c03c136c16342b0a9bd4024107db6f7bc1c50227723fb90R51) is a good idea, but I'm not sure where else to put it. 