### PR TITLE
Try2: Enrich uri bug fixes

### DIFF
--- a/lib/all.rb
+++ b/lib/all.rb
@@ -150,3 +150,12 @@ begin
 rescue LoadError => e 
   # unable to load gem, presumably unavailable
 end
+
+###
+# load in ruclei if available, fail silently if not
+###
+begin
+  require 'ruclei'
+rescue LoadError => e 
+  # unable to load gem, presumably unavailable
+end

--- a/lib/intrigue-tasks.rb
+++ b/lib/intrigue-tasks.rb
@@ -58,7 +58,6 @@ begin  # try to load runtime deps
   require 'whois-parser'
   require 'whoisology'
   require 'zip'
-  require 'ruclei'
 
 rescue LoadError => e 
   puts "ERROR! Unable to load a dep, functionality may be limited: #{e}"

--- a/lib/intrigue-tasks.rb
+++ b/lib/intrigue-tasks.rb
@@ -49,7 +49,6 @@ begin  # try to load runtime deps
   require 'resolv-replace'
   require 'rex/sslscan'
   require 'rexml/document'
-  require 'ruclei'
   require 'snmp'
   require 'spidr'
   require 'towerdata_api'
@@ -59,6 +58,7 @@ begin  # try to load runtime deps
   require 'whois-parser'
   require 'whoisology'
   require 'zip'
+  require 'ruclei'
 
 rescue LoadError => e 
   puts "ERROR! Unable to load a dep, functionality may be limited: #{e}"

--- a/lib/tasks/helpers/vulndb.rb
+++ b/lib/tasks/helpers/vulndb.rb
@@ -48,7 +48,6 @@ module VulnDb
 
   class Cpe
     include Intrigue::Task::Web
-    require 'versionomy'
 
     def initialize(cpe_string)
       


### PR DESCRIPTION
After understanding the root issue better, the loading of nuclei has been moved to `all.rb`. Additionally, the initial changes and bugfixes have been remediated.