### PR TITLE
hashes should have a standard type

### DIFF
--- a/lib/entities/file_hash.rb
+++ b/lib/entities/file_hash.rb
@@ -11,17 +11,18 @@ class FileHash < Intrigue::Core::Model::Entity
     }
   end
 
-  def validate_entity
-    # check that our regex for the hash matches
-    !supported_hash_types.select{|x| x[:regex] =~ name }.empty?
-  end
-
   # just a list of supported types and their regexen
-  def supported_hash_types
+  def self.supported_hash_types
     [
       { type:"md5", regex: /^[a-f0-9]{5,32}$/},
-      { type:"sha1", regex: /^[a-f0-9]{5,40}$/}
+      { type:"sha1", regex: /^[a-f0-9]{5,40}$/},
+      { type:"sha2-256", regex: /^\b[A-Fa-f0-9]{64}\b$/}
     ]
+  end
+
+  def validate_entity
+    # check that our regex for the hash matches
+    !self.class.supported_hash_types.select{|x| x[:regex] =~ name }.empty?
   end
 
   def scoped?

--- a/lib/machines/threat_investigation.rb
+++ b/lib/machines/threat_investigation.rb
@@ -47,7 +47,7 @@ class RunInvestigationTask < Intrigue::Machine::Base
         start_recursive_task(task_result,"threat/search_quad9_dns", entity)
 
         # Checks IPs vs Talos IP BlackList for threat data
-        start_recursive_task(task_result,"search_talos_blacklist", entity)
+        start_recursive_task(task_result,"threat/search_talos_blacklist", entity)
 
         # Looks up whether hosts are blocked by Yandex DNS
         start_recursive_task(task_result,"threat/search_yandex_dns", entity)

--- a/lib/tasks/enrich/file_hash.rb
+++ b/lib/tasks/enrich/file_hash.rb
@@ -1,0 +1,43 @@
+module Intrigue
+  module Task
+  module Enrich
+  class FileHash < Intrigue::Task::BaseTask
+  
+    def self.metadata
+      {
+        :name => "enrich/file_hash",
+        :pretty_name => "Enrich FileHash",
+        :authors => ["jcran"],
+        :description => "Fills in details for an FileHash",
+        :references => [],
+        :allowed_types => ["FileHash"],
+        :type => "enrichment",
+        :passive => true,
+        :example_entities => [
+          {"type" => "FileHash", "details" => {"name" => "c2c30b3a287d82f88753c85cfb11ec9eb1466bad"}}],
+        :allowed_options => [],
+        :created_types => ["Domain"]
+      }
+    end
+  
+    def run
+  
+      file_hash = _get_entity_name.strip
+      
+      # determine the type based on regex 
+      method = Intrigue::Entity::FileHash.supported_hash_types.find{|x| x[:regex] =~ file_hash }
+      if method
+        our_type = method[:type]
+      else 
+        our_type = "unknown"
+      end
+
+      # save the hash type
+      _set_entity_detail("hash_type", our_type)
+      
+    end
+  
+  end
+  end
+  end
+  end


### PR DESCRIPTION
This PR adds an enrich task for FileHash entities that attempts to infer what type of hash it is. Also fixes a bug in the threat_investigation machine.