### PR TITLE
Fix gitrob

### DIFF
--- a/lib/tasks/gitrob.rb
+++ b/lib/tasks/gitrob.rb
@@ -82,6 +82,7 @@ class Gitrob < BaseTask
     end
 
     # create findings
+    suspicious_commits = []
     if output["Findings"]
       finding_hash = {}
       output["Findings"].each do |f|
@@ -89,23 +90,26 @@ class Gitrob < BaseTask
         # skip if credentials or password is used in the fileurl
         next if (f["Description"] == "Contains word: credential" && f["FilePath"] =~ /credential.html/i )
         next if (f["Description"] == "Contains word: password" && f["FilePath"] =~ /password.html/i )
+        sp = {}
+        sp["Commit URL"] = "#{f["CommitUrl"]}"
+        sp["Repository URL"] = "#{f['RepositoryUrl']}"
+        sp["Commit Author"] = "#{f["CommitAuthor"]}"
+        sp["Commit Message"] = "#{f["CommitMessage"]}"
+        sp["Action"] = "#{f["Action"]}"
+        sp["File URL"] = "#{f["FileUrl"]}"
 
-        ############################################
-        ###      New Issue                      ###
-        ###########################################
-        _create_linked_issue("suspicious_commit", {
-          name: "Suspicious #{f["Action"]} Commit Found In Github Repository",
-          detailed_description:  "A suspicious commit was found in a public Github repository.\n" +
-                        "Repository URL: #{f['RepositoryUrl']}\n" +
-                        "Commit Author: #{f["CommitAuthor"]}\n" +
-                        "Commit Message #{f["CommitMessage"]}\n" +
-                        "Details: #{f["Action"]} #{f["Description"]} at #{f["FileUrl"]}\n\n#{f["Comment"]}",
-          details: f.merge({uri: "#{f["CommitUrl"]}"})
-        })
+        suspicious_commits.append(sp)
       end
-
     else
       _log "No findings!"
+    end
+
+    if suspicious_commits.length > 0
+      _create_linked_issue("suspicious_commit", {
+        name: "Suspicious commit(s) found in Github Repository",
+        detailed_description:  "One or more suspicious commits were found in a public Github repository",
+        details: suspicious_commits
+      })
     end
 
     # clean up

--- a/lib/tasks/gitrob.rb
+++ b/lib/tasks/gitrob.rb
@@ -29,8 +29,10 @@ class Gitrob < BaseTask
 
     # task assumes gitrob is in our path and properly configured
     _log "Starting Gitrob on #{github_account}, saving to #{temp_file}!"
-    command_string = "gitrob -github-access-token #{token} -save #{temp_file} #{github_account}"
-    _unsafe_system_timed command_string, 30
+    command_string = "gitrob -github-access-token #{token} -save #{temp_file} -exit-on-finish -no-expand-orgs -commit-depth 20 --threads 20 -in-mem-clone #{github_account}"
+    # gitrob tends to hang so we set a timeout of 5 minutes (300 seconds)
+    # the gitrob fork we use requires two files in the current working directory, hence setting working dir to ~/bin/data/gitrob
+    _unsafe_system_timed command_string, 300, "#{Dir.home}/bin/data/gitrob"
     _log "Gitrob finished on #{github_account}!"
 
     # parse output

--- a/lib/tasks/gitrob.rb
+++ b/lib/tasks/gitrob.rb
@@ -30,7 +30,7 @@ class Gitrob < BaseTask
     # task assumes gitrob is in our path and properly configured
     _log "Starting Gitrob on #{github_account}, saving to #{temp_file}!"
     command_string = "gitrob -github-access-token #{token} -save #{temp_file} #{github_account}"
-    _unsafe_system command_string
+    _unsafe_system_timed command_string, 30
     _log "Gitrob finished on #{github_account}!"
 
     # parse output

--- a/lib/tasks/helpers/generic.rb
+++ b/lib/tasks/helpers/generic.rb
@@ -101,6 +101,43 @@ module Generic
     end
   end
 
+
+  def _unsafe_system_timed(command, timeout, tick=1)
+    output = ''
+    begin
+      # Start task in another thread, which spawns a process
+      stdin, stderrout, thread = Open3.popen2e(command)
+      # Get the pid of the spawned process
+      pid = thread[:pid]
+      start = Time.now
+
+      while (Time.now - start) < timeout and thread.alive?
+        # Wait up to `tick` seconds for output/error data
+        Kernel.select([stderrout], nil, nil, tick)
+        # Try to read the data
+        begin
+          output << stderrout.read_nonblock(4096)
+        rescue IO::WaitReadable
+          # A read would block, so loop around for another select
+        rescue EOFError
+          # Command has completed, not really an error...
+          break
+        end
+      end
+      # Give Ruby time to clean up the other thread
+      sleep 1
+
+      if thread.alive?
+        # We need to kill the process, because killing the thread leaves
+        # the process alive but detached, annoyingly enough.
+        Process.kill("TERM", pid)
+      end
+    ensure
+      stdin.close if stdin
+      stderrout.close if stderrout
+    end
+    return output
+  end
   ###
   ### Helpers for handling encoding
   ###

--- a/util/bootstrap.sh
+++ b/util/bootstrap.sh
@@ -172,10 +172,13 @@ GO111MODULE=on go get -u -v github.com/ffuf/ffuf
 # gitrob
 echo "[+] Getting Gitrob... "
 cd $HOME/bin
-wget -q https://github.com/michenriksen/gitrob/releases/download/v2.0.0-beta/gitrob_linux_amd64_2.0.0-beta.zip
-unzip gitrob_linux_amd64_2.0.0-beta.zip
+wget -q https://github.com/codeEmitter/gitrob/releases/download/v3.4.1-beta/gitrob_linux_amd64_3.4.1-beta.zip
+unzip gitrob_linux_amd64_3.4.1-beta.zip
 chmod +x gitrob
-rm gitrob_linux_amd64_2.0.0-beta.zip README.md
+mkdir data
+mkdir data/gitrob
+mv *.json data/gitrob
+rm gitrob_linux_amd64_3.4.1-beta.zip README.md
 cd $HOME
 
 # gobuster


### PR DESCRIPTION
Uses the following fork of gitrob: https://github.com/codeEmitter/gitrob . This fork requires some json files with signatures, which are added to bin/data/gitrob.

Running gitrob takes very long if not limited by depth and other parameters. The current parameters still take up to 2-3 min to complete. From my testing, most of the impact is done my commit-depth.