### PR TITLE
Add check for Wide-Scoped (overlyscoped) Cookies

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "intrigue-core" do |x|
 
-    x.vm.provision :shell, privileged: false, path: "util/bootstrap-standalone.sh"
+    x.vm.provision :shell, privileged: false, path: "util/bootstrap.sh"
 	x.vm.provision "shell", privileged: false, inline: <<-SHELL
 		cd /home/ubuntu/core
 		sudo -u postgres createuser vagrant -s

--- a/lib/issues/insecure_cookie_widescoped.rb
+++ b/lib/issues/insecure_cookie_widescoped.rb
@@ -1,0 +1,25 @@
+module Intrigue
+  module Issue
+  class InsecureCookieWideScoped < BaseIssue
+  
+    def self.generate(instance_details={})
+      {
+        added: "2020-01-01",
+        name: "insecure_cookie_widescoped",
+        pretty_name: "Insecure Cookie (Widescoped)",
+        severity: 5,
+        category: "misconfiguration",
+        status: "confirmed",
+        description: "A wide scoped cookie can be accessed by applications sharing the same base domain (subdomains) which can result in compromise of the cookie in certain scenarios such as subdomain takeovers, cross-site scripting and more. This issue can become dangerous if said cookie is a session cookie.",
+        remediation: "Ensure cookies are properly scoped.",
+        references: [ # types: description, remediation, detection_rule, exploit, threat_intel
+          { type: "description", uri: "https://vulncat.fortify.com/en/detail?id=desc.config.php.cookie_security_overly_broad_session_cookie_domain" },
+          { type: "remediation", uri: "https://vulncat.fortify.com/en/detail?id=desc.config.php.cookie_security_overly_broad_session_cookie_domain" }
+        ]
+      }.merge!(instance_details)
+    end
+  
+  end
+  end
+  end
+  

--- a/lib/tasks/enrich/uri.rb
+++ b/lib/tasks/enrich/uri.rb
@@ -140,6 +140,7 @@ class Uri < Intrigue::Task::BaseTask
       # TODO - cookie scoped to parent domain
       if !set_cookie.empty? 
         domain_cookies = set_cookie.map{|x| x.split(";").detect{|x| x.match(/Domain=/i) }}.compact.map{|x|x.strip}
+        _log "Domain Cookies: #{domain_cookies}"
       end
 
       if scheme == "https"

--- a/lib/tasks/enrich/uri.rb
+++ b/lib/tasks/enrich/uri.rb
@@ -140,7 +140,8 @@ class Uri < Intrigue::Task::BaseTask
       # TODO - cookie scoped to parent domain
       if !set_cookie.empty? 
         domain_cookies = set_cookie.map{|x| x.split(";").detect{|x| x.match(/Domain=/i) }}.compact.map{|x|x.strip}
-        _log "Domain Cookies: #{domain_cookies}"
+        
+        
       end
 
       if scheme == "https"
@@ -158,6 +159,10 @@ class Uri < Intrigue::Task::BaseTask
         _log "Got cert's alt names: #{alt_names}"
 
         if set_cookie
+
+          if set_cookie.map{|x| x.split(";").detect{|x| x.match(/Domain=".#{parse_domain_name(uri)}"/i)}}
+            _create_wide_scoped_cookie_issue(uri, set_cookie)
+          end
 
           # create an issue if not detected
           if set_cookie.map{|x| x.split(";").detect{|x| x.match(/httponly/i) }}.compact.empty?

--- a/lib/tasks/enrich/uri.rb
+++ b/lib/tasks/enrich/uri.rb
@@ -140,8 +140,6 @@ class Uri < Intrigue::Task::BaseTask
       # TODO - cookie scoped to parent domain
       if !set_cookie.empty? 
         domain_cookies = set_cookie.map{|x| x.split(";").detect{|x| x.match(/Domain=/i) }}.compact.map{|x|x.strip}
-        
-        
       end
 
       if scheme == "https"

--- a/lib/tasks/helpers/issue.rb
+++ b/lib/tasks/helpers/issue.rb
@@ -81,6 +81,15 @@ module Issue
     _create_linked_issue("content_issue", { uri: uri, check: check })
   end
 
+  def _create_wide_scoped_cookie_issue(uri, cookie, severity=5)
+    hostname = URI(uri).hostname
+    return if hostname.match(ipv4_regex) || hostname.match(ipv6_regex)
+    
+    addtl_details = { cookie: cookie }
+    _create_linked_issue("insecure_cookie_widescoped", addtl_details)
+  end
+
+
   def _create_missing_cookie_attribute_http_only_issue(uri, cookie, severity=5)
     
     # skip this for anything other than hostnames 


### PR DESCRIPTION
Hi team,

In this PR a check is added for wide scoped cookies and if one is found; an informational issue is created. Along with the check; a small modification has been made in the `Vagrantfile` to point to the updated installation script.

Best regards,
Maxim