### PR TITLE
automatically start intrigue on container stop/start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,9 +78,11 @@ RUN printf "#!/bin/bash \
 \n # \
 \n # Remove instructions because we're in Docker\
 \n sed -i \"s/boxes -a c .*//\" ~/.bash_profile \
-\n sed -i \"s/Browse to https:\/\/\\$ip:7777/Browse to https:\/\/localhost:7777/\" /home/ubuntu/core/util/intriguectl \
+\n sed -i \"s/Browse to https:\/\/.ip:7777/Browse to https:\/\/localhost:7777/\" /home/ubuntu/core/util/intriguectl \
 \n sed -i \"s/To start intrigue, run 'intriguectl start'//\" /home/ubuntu/core/util/intriguectl \
 \n source ~/.bash_profile \
+\n echo \"source ~/.bash_profile\" >> ~/.bashrc \
+\n echo \"intriguectl start\" >> ~/.bash_profile \
 \n # setup and start commands \
 \n /home/ubuntu/core/util/intriguectl setup \
 \n /home/ubuntu/core/util/intriguectl start \


### PR DESCRIPTION
This PR enables automatic startup of intrigue when a docker container is stopped and later started again. This only affects docker images. Standard operation is still required to go through `intriguectl` command