### PR TITLE
better support ASNs in external network profile

### DIFF
--- a/lib/entities/autonomous_system.rb
+++ b/lib/entities/autonomous_system.rb
@@ -12,7 +12,7 @@ class AutonomousSystem < Intrigue::Core::Model::Entity
   end
 
   def validate_entity
-    name.match /^(as|AS).?[0-9].*$/
+    name.match asn_regex
   end
 
   def scoped?

--- a/lib/system/helpers.rb
+++ b/lib/system/helpers.rb
@@ -15,6 +15,8 @@ module System
     def discern_entity_types_from_name(str)
       if str.is_ip_address?
         ["IpAddress"]
+      elsif str =~ asn_regex 
+        ["AutonomousSystem"]
       elsif str =~ dns_regex && (parse_domain_name(str) == str)
         ["Domain"]
       elsif str =~ dns_regex 

--- a/lib/system/validations.rb
+++ b/lib/system/validations.rb
@@ -5,6 +5,11 @@ module System
   module Validations
 
     ### Standard Validations, for use throughout the platform
+    
+    def asn_regex
+      /^(as|AS).?[0-9].*$/
+    end
+    
     # https://tools.ietf.org/html/rfc1123
     def ipv4_regex
       /(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/

--- a/lib/tasks/asn_to_netblocks.rb
+++ b/lib/tasks/asn_to_netblocks.rb
@@ -1,0 +1,65 @@
+module Intrigue
+  module Task
+  class AsnToNetblocks < BaseTask
+  
+    def self.metadata
+      {
+        :name => "asn_to_netblocks",
+        :pretty_name => "ASN to Netblocks",
+        :authors => ["jcran", ],
+        :description => "Use BGP Data to find Networks for a given ASN.",
+        :references => [],
+        :type => "discovery",
+        :passive => true,
+        :allowed_types => ["AutonomousSystem"],
+        :example_entities => [
+          {"type" => "AutonomousSystem", "details" => {"name" => "AS17676"}}
+        ],
+        :allowed_options => [],
+        :created_types => ["Netblock"]
+      }
+    end
+  
+    def run
+      super
+
+      # get our enitty 
+      asn = _get_entity_name
+
+      # get the netblocks 
+      r = asn_to_netblocks(asn.gsub("as",""))
+
+      # create the organization entity
+      if r["org"]
+        org_string = r["org"].split(",").first
+        _create_entity "Organization", {"name" => "#{org_string}", "full" => org_string}
+      end
+
+      # make sure we have some, or return
+      return unless r["netblocks"]
+
+      # create a netblock entity for each
+      r["netblocks"].each do |nb|
+        _create_entity "NetBlock", {
+          "name" => "#{nb}", 
+          "organization_name" => org_string, 
+          "as_number" => asn
+        }
+      end
+    
+    end
+  
+    def asn_to_netblocks(entity_name)
+      begin
+        resp = http_get_body "https://app.intrigue.io/api/bgp/asn/#{URI.escape(entity_name)}"
+
+        json_resp = JSON.parse resp
+      rescue JSON::ParserError => e
+        _log_error "Error parsing: #{e}"
+      end
+    end
+  
+  end
+  end
+  end
+  

--- a/lib/tasks/asn_to_netblocks.rb
+++ b/lib/tasks/asn_to_netblocks.rb
@@ -6,7 +6,7 @@ module Intrigue
       {
         :name => "asn_to_netblocks",
         :pretty_name => "ASN to Netblocks",
-        :authors => ["jcran", ],
+        :authors => ["jcran", "Punisher876"],
         :description => "Use BGP Data to find Networks for a given ASN.",
         :references => [],
         :type => "discovery",

--- a/lib/tasks/enrich/uri.rb
+++ b/lib/tasks/enrich/uri.rb
@@ -417,6 +417,3 @@ end
 end
 end
 end
-
-
-

--- a/lib/tasks/search_bgp.rb
+++ b/lib/tasks/search_bgp.rb
@@ -55,7 +55,7 @@ class SearchBgp < BaseTask
 
     begin
       lookup_name = entity_name.split("/").first
-      json_resp = JSON.parse http_get_body "https://intrigue.io/api/bgp/netblock/search/#{lookup_name}"
+      json_resp = JSON.parse http_get_body "https://app.intrigue.io/api/bgp/netblock/search/#{lookup_name}"
 
       json_resp.each do |r|
 

--- a/lib/workflows/profile_organization_external_light_active.yml
+++ b/lib/workflows/profile_organization_external_light_active.yml
@@ -7,6 +7,8 @@ maintainer: jcran
 flow: recursive
 description: Performs a light active attack surface discovery for organizations. Start with a Domain or NetBlock.
 definition:
+  AutonomousSystem: 
+  - task: asn_to_netblocks
   AwsS3Bucket: 
   - task: aws_s3_put_file
   Domain:


### PR DESCRIPTION
Based on feedback from @Punisher876 in the slack channel, directly allow an ASN to be provided to a workflow, and convert it into netblocks automatically. 