### PR TITLE
remove all task results for all entities

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -22,6 +22,7 @@ module Model
     def delete!
       self.scan_results.each{|x| x.delete }
       self.task_results.each{|x| x.delete }
+      self.entities.each{ |x| x.remove_all_task_results}
       self.entities.each{|x| x.delete }
       self.issues.each{|x| x.delete }
       self.delete


### PR DESCRIPTION
This removes all task results for all entities, effectively ensuring the many_to_many association table between entities and task_results is emptied when a project is deleted.