### PR TITLE
Fix recursive dns regex problem

### DIFF
--- a/lib/tasks/helpers/web_content.rb
+++ b/lib/tasks/helpers/web_content.rb
@@ -219,7 +219,7 @@ module WebContent
      end
 
      # Scan for dns records
-     potential_dns_records = content.scan(dns_regex)
+     potential_dns_records = URI.decode(content).scan(dns_regex)
 
      potential_dns_records.compact.each do |potential_dns_record|
 

--- a/lib/tasks/helpers/web_content.rb
+++ b/lib/tasks/helpers/web_content.rb
@@ -219,7 +219,8 @@ module WebContent
      end
 
      # Scan for dns records
-     potential_dns_records = URI.decode(content).scan(dns_regex)
+     # CGI::unescape does not throw errors according to docs: https://www.rubydoc.info/stdlib/cgi/CGI/Escape#unescape-instance_method
+     potential_dns_records = CGI::unescape(content).scan(dns_regex)
 
      potential_dns_records.compact.each do |potential_dns_record|
 


### PR DESCRIPTION
Fixes the problem where URL-encoded links are regex-ed as part of a domain name. 