### PR TITLE
Removing thinkific since it is too generic and not verifyable

### DIFF
--- a/lib/tasks/uri_check_subdomain_hijack.rb
+++ b/lib/tasks/uri_check_subdomain_hijack.rb
@@ -224,9 +224,6 @@ class UriCheckSudomainHijack  < BaseTask
       elsif response_body.match /Oops \- We didn\'t find your site/i
         _create_hijackable_subdomain_issue "Teamwork", uri, "potential"
 
-      elsif response_body.match /You may have mistyped the address or the page may have moved/i
-        _create_hijackable_subdomain_issue "Thinkific", uri, "potential"
-
       elsif response_body.match(/Building a brand of your own\?/) || 
               response_body.match(/to target URL\: \<a href\=\"https\:\/\/tictail\.com/) || 
               response_body.match(/Start selling on Tictail/)


### PR DESCRIPTION
Removing thinkific since it is too generic and not verifyable. I was unable to find a reliable way to test or confirm a subdomain hijack is possible.