### PR TITLE
Scoping refactor and tests

### DIFF
--- a/app/models/global_entity.rb
+++ b/app/models/global_entity.rb
@@ -15,9 +15,27 @@ module Model
 
     def self.load_global_namespace(data)
       (data["entities"] || []).each do |x|
-        Intrigue::Core::Model::GlobalEntity.update_or_create(:name => x["name"], :type => x["type"], :namespace => x["namespace"])
+        Intrigue::Core::Model::GlobalEntity.update_or_create({
+          :name => x["name"], 
+          :type => "#{x["type"]}".split(":").last, # shorten to just the type_string 
+          :namespace => x["namespace"]
+        })
       end
     end
+
+    def self.scope_verification_types
+      scope_verification_types = [
+        "DnsRecord",
+        "Domain",
+        "EmailAddress",
+        "Organization",
+        "Nameserver",
+        "Uri",
+        "UniqueKeyword",
+        "UniqueToken",
+      ]
+    end
+
 
   end
   

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,7 +6,10 @@ module Model
     plugin :serialization, :json, :options, :handlers, :allowed_namespaces
     plugin :timestamps
 
+    self.raise_on_save_failure = true
+
     one_to_many :logger
+    one_to_many :alias_groups
     one_to_many :task_results
     one_to_many :scan_results
     one_to_many :issues
@@ -22,10 +25,12 @@ module Model
     def delete!
       self.scan_results.each{|x| x.delete }
       self.task_results.each{|x| x.delete }
+      self.alias_groups.each{ |x| x.delete}
+      self.issues.each{|x| x.delete }
       self.entities.each{ |x| x.remove_all_task_results}
       self.entities.each{|x| x.delete }
-      self.issues.each{|x| x.delete }
       self.delete
+    true 
     end
 
     def issues
@@ -192,18 +197,21 @@ module Model
     out
     end
 
-    def globally_traversable_entity?(entity_type, entity_name)
+    def globally_traversable_entity?(entity)
         
       # by default things are not traversable
       out = false
 
       # first check to see if we know about this exact entity (type matters too)
       #puts "Looking for global entity: #{entity_type} #{entity_name}"
-      global_entity = Intrigue::Core::Model::GlobalEntity.first(:name => entity_name, :type => entity_type)
+      global_entity = Intrigue::Core::Model::GlobalEntity.first(:name => entity.name, :type => entity.type_string)
+
+      ###
+      ## Handle the case of an exact match 
+      ###
 
       # If we know it exists, is it in our project (cool) or someone else (no traverse!)
       if global_entity
-        #puts "Global entity found: #{entity_type} #{entity_name}!"
         
         # we need to have a namespace to validate against
         if self.allowed_namespaces
@@ -219,9 +227,11 @@ module Model
           return false
         end
 
-      else 
-        #puts "No Global entity found, trying harder!"
       end
+
+      ###
+      ## Handle the case of a near match 
+      ###
 
       # okay so if we made it this far, we may or may not have a matching entiy, so now 
       # we need to find if it matches based on regex... since entities can have a couple
@@ -230,202 +240,127 @@ module Model
       # then check each for a match 
       found_entity = nil
 
-      ## Okay let's get smart by getting down to the smallest searchable unit first
-      searchable_name = nil
-              
-      if entity_type == "Domain"
-        # this should have gotten caught above... 
-        serchable_type = "Domain"
-        searchable_name = parse_domain_name(entity_name)
-      elsif entity_type == "DnsRecord"  
-        serchable_type = "Domain"
-        searchable_name = parse_domain_name(entity_name)
-      elsif entity_type == "EmailAddress"  
-        serchable_type = "Domain"
-        searchable_name = parse_domain_name(entity_name.split("@").last)
-      elsif entity_type == "Nameserver"  
-        serchable_type = "Domain"
-        searchable_name = parse_domain_name(entity_name)
-      elsif entity_type == "Uri"  || entity_type == "ApiEndpoint"  
-        serchable_type = "Domain"
-        searchable_name = parse_domain_name(URI.parse(entity_name).host)
-      
-      ## We can directly compare these types 
-      elsif ( entity_type == "UniqueKeyword" || 
-                entity_type == "UniqueToken"  || 
-                  entity_type =="GithubAccount" || 
-                    entity_type == "GithubRepository" ||
-                      entity_type == "NetBlock" || 
-                      entity_type == "NetworkService" || 
-                        entity_type == "IpAddress" || 
-                        entity_type == "IosApp" || 
-                        entity_type == "AndroidApp" ||
-                        entity_type == "Organization" ) 
-
-        searchable_type = entity_type
-        searchable_name = entity_name
-      
-      # TODO ... webaccount (which is scoped?)
-
-      end
-
       # now form the query, taking into acount the filter if we can
-      if searchable_name && searchable_type
-        found_entity = Intrigue::Core::Model::GlobalEntity.first(
-            :type => searchable_type, :name => searchable_name )
-      
-      
-      ###
-      ### This was disabled 12/24/2020 ... as we listed the directly compareable entities above
-      ### and the expense of doing a global lookup / traverse, repeatedly, is significant.
-      ###
+      found_entity = Intrigue::Core::Model::GlobalEntity.first(
+          :type => entity.type_string, :name => entity.name )
+    
 
-      #else
-      #  global_entities = Intrigue::Core::Model::GlobalEntity.all
-      #  
-      #  global_entities.each do |ge|
-      #  
-      #    # this needs a couple (3) cases:
-      #   # 1) case where we're an EXACT match (ey.com)
-      #    # 2) case where we're a subdomain of an exception domain (x.ey.com)
-      #    # 3) case where we're a uri and should match an exception domain (https://ey.com)
-      #    # none of these cases should match the case: jcpenney.com
-      #    if (entity_name.downcase =~ /^#{Regexp.escape(ge.name.downcase)}(:[0-9]*)?$/ ||
-      #      entity_name.downcase =~ /^.*\.#{Regexp.escape(ge.name.downcase)}(:[0-9]*)?$/ ||
-      #      entity_name.downcase =~ /^https?:\/\/#{Regexp.escape(ge.name.downcase)}(:[0-9]*)?$/)
-      #      
-      #      #okay we found it... now we need to check if it's an allowed project
-      #      found_entity = ge
-      #    end
-      #  end
+      if found_entity && !self.allowed_namespaces.empty? # now lets check if we have an allowance for it
 
-      end
-
-    if found_entity && !self.allowed_namespaces.empty? # now lets check if we have an allowance for it
-
+        # check our namespaces for a match! 
         (self.allowed_namespaces || []).each do |namespace|
-        if found_entity.namespace.downcase == namespace.downcase # Good! 
-          return true 
+          if found_entity.namespace.downcase == namespace.downcase # Good! 
+            return true 
+          end
         end
+
+        out = false
+      else # we never found it or we don't care (no namespaces)! 
+        out = true 
       end
-
-      out = false
-    else # we never found it or we don't care (no namespaces)! 
-      out = true 
-    end
-
-    #puts "Result for: #{entity_type} #{entity_name} in project #{project.name}: #{out}" 
 
     out 
     end
 
-
     ###
     ### Use this when you want to scope in stuff, but generally prefer 'traversable_entity?'
     ###
-    def allow_list_entity?(type_string, entity_name)
+    def allow_list_entity?(entity)      
+      our_scope_verification_list = entity.scope_verification_list
+
+      svt = Intrigue::Core::Model::GlobalEntity.scope_verification_types
+
+      our_scope_verification_list.each do |h|
+
+        type_string = h[:type_string]
+        entity_name = h[:name]
+
+        # skip anything else thats not verifiable!!
+        next unless svt.include? type_string
+
+        # if it's an explicit seed, it's whitelisted 
+        return true if seed_entity?(type_string,entity_name)
+        #return true unless Intrigue::Core::Model::GlobalEntity.count > 0
+  
+        seeds.where(Sequel.ilike(:name, "%#{entity_name}%")).all.each do |s| 
+          if entity_name =~ /[\.\s\@]#{Regexp.escape(s.name)}/i
+            return true # matches a seed pattern, it's whitelisted
+          end
+        end
       
-      # if it's an explicit seed, it's whitelisted 
-      return true if seed_entity?(type_string,entity_name)
-      #return true unless Intrigue::Core::Model::GlobalEntity.count > 0
-
-      ### CHECK OUR SEED ENTITIES TO SEE IF THE TEXT MATCHES A DOMAIN
-      ######################################################
-      # if it matches an explicit seed pattern, it's always traversable
-      scope_check_entity_types = [
-        "Intrigue::Entity::DnsRecord",
-        "Intrigue::Entity::Domain",
-        "Intrigue::Entity::EmailAddress",
-        "Intrigue::Entity::Organization",
-        "Intrigue::Entity::Nameserver",
-        "Intrigue::Entity::Uri" 
-      ]
-
-      # skip anything else thats not verifiable!!
-      return false unless scope_check_entity_types.include? "Intrigue::Entity::#{type_string}"
-
- 
-      seeds.where(Sequel.ilike(:name, "%#{entity_name}%")).all.each do |s| 
-        if entity_name =~ /[\.\s\@]#{Regexp.escape(s.name)}/i
-          return true # matches a seed pattern, it's whitelisted
+        # Check standard exceptions (hardcoded list) first if we
+        #  show up here (and we werent' a seed), we should skip
+        if use_standard_exceptions
+          if standard_no_traverse?(entity_name, type_string)
+            #puts 'Matched a standard exception, not whitelisted'
+            return false 
+          end
         end
-      end
-    
-      # Check standard exceptions (hardcoded list) first if we
-      #  show up here (and we werent' a seed), we should skip
-      if use_standard_exceptions
-        if standard_no_traverse?(entity_name, type_string)
-          #puts 'Matched a standard exception, not whitelisted'
-          return false 
-        end
-      end
 
-      # now check the global intel 
-      verifiable_entity_types = ["DnsRecord", "Domain", "EmailAddress", "NameServer" "Uri"]
-      if verifiable_entity_types.include? type_string
-        # if we don't have a list, safe to return false now, otherwise proceed to 
-        # additional exceptions which are provided as an attribute on the object
-        unless globally_traversable_entity?(type_string, entity_name)
-          puts 'Global intel says not traversable, returning false'
-          return false 
+        # now check the global intel 
+        if svt.include? type_string
+          # if we don't have a list, safe to return false now, otherwise proceed to 
+          # additional exceptions which are provided as an attribute on the object
+          unless globally_traversable_entity?(entity)
+            puts 'Global intel says not traversable, returning false'
+            return false 
+          end
         end
-      end
-      
+        
+      end 
+
     ###
     # Defaulting to not traversable (Whitelist approach!)
     ###
+
     false
     end
 
     ###
     ### Use this when you wan to scope out stuff based on rules or global intel
     ###
-    def deny_list_entity?(type_string, entity_name)
+    def deny_list_entity?(entity)
 
-      # if it's an explicit seed, it's not blacklisted 
-      return false if seed_entity?(type_string,entity_name)
-      return false unless Intrigue::Core::Model::GlobalEntity.first
+      our_scope_verification_list = entity.scope_verification_list
 
-      ### CHECK OUR SEED ENTITIES TO SEE IF THE TEXT MATCHES A DOMAIN
-      ######################################################
-      # if it matches an explicit seed pattern
-      scope_check_entity_types = [
-        "Intrigue::Entity::DnsRecord",
-        "Intrigue::Entity::Domain",
-        "Intrigue::Entity::EmailAddress",
-        "Intrigue::Entity::Organization",
-        "Intrigue::Entity::Nameserver",
-        "Intrigue::Entity::Uri" 
-      ]
+      svt = Intrigue::Core::Model::GlobalEntity.scope_verification_types
 
-      # not blacklisted if we're not one of the check types
-      return false unless scope_check_entity_types.include? "Intrigue::Entity::#{type_string}"
+      our_scope_verification_list.each do |h|
 
-      seeds.where(Sequel.ilike(:name, "%#{entity_name}%")).all.each do |s| 
-        if entity_name =~ /[\.\s\@]#{Regexp.escape(s.name)}/i
-          return false # not blacklisted if we're matching a seed derivative
+        type_string = h[:type_string]
+        entity_name = h[:name]
+
+        # skip anything else thats not verifiable!!
+        next unless svt.include? "#{type_string}"
+
+        # if it's an explicit seed, it's not blacklisted 
+        return false if seed_entity?(type_string,entity_name)
+        return false unless Intrigue::Core::Model::GlobalEntity.first
+
+        seeds.where(Sequel.ilike(:name, "%#{entity_name}%")).all.each do |s| 
+          if entity_name =~ /[\.\s\@]#{Regexp.escape(s.name)}/i
+            return false # not blacklisted if we're matching a seed derivative
+          end
         end
-      end
-    
-      # Check standard exceptions (hardcoded list) first if we 
-      # show up here (and we werent' a seed), we should skip
-      if use_standard_exceptions
-        if standard_no_traverse?(entity_name, type_string)
-          return true  # matched a blacklist 
+      
+        # Check standard exceptions (hardcoded list) first if we 
+        # show up here (and we werent' a seed), we should skip
+        if use_standard_exceptions
+          if standard_no_traverse?(entity_name, type_string)
+            return true  # matched a blacklist 
+          end
         end
-      end
 
-      # now check the global intel 
-      verifiable_entity_types = ["DnsRecord", "Domain", "EmailAddress", "NameServer" "Uri"]
-      if verifiable_entity_types.include? type_string
+        # now check the global intel 
         # if we don't have a list, safe to return false now, otherwise proceed to 
         # additional exceptions which are provided as an attribute on the object
-        if !globally_traversable_entity?(type_string, entity_name)
+        if !globally_traversable_entity?(entity)
           puts 'Global intel says not traversable so we are blacklisted, returning true'
           return true 
         end
-      end
       
+      end
+
     ###
     # we made it this far, not blacklisted!
     ###
@@ -440,9 +375,10 @@ module Model
     ###
     ### DEFAULTS TO FALSE!!! WHITELIST APPROACH
     ###
-    def traversable_entity?(type_string, entity_name)
-      return true if allow_list_entity?(type_string, entity_name)
-      return false if deny_list_entity?(type_string, entity_name)
+    def traversable_entity?(entity)
+
+      return true if allow_list_entity?(entity)
+      return false if deny_list_entity?(entity)
     
     # otherwise, permissive
     true

--- a/app/models/task_result.rb
+++ b/app/models/task_result.rb
@@ -14,6 +14,8 @@ module Model
     many_to_one :project
     many_to_one :base_entity, :class => :'Intrigue::Core::Model::Entity', :key => :base_entity_id
 
+    #self.raise_on_save_failure = true
+
     include Intrigue::Core::ModelMixins::Handleable
 
     def self.scope_by_project(project_name)

--- a/app/views/entities/detail.erb
+++ b/app/views/entities/detail.erb
@@ -64,7 +64,7 @@
 
     <ul>
       <li>Enriched: <%= @entity.enriched ? checkmark_image : xmark_image %></li>
-      <li>Scoped: <%= @entity.scoped ? checkmark_image : xmark_image %> (<%=h @entity.scoped_reason%>)</li>
+      <li>Scoped: <%= @entity.scoped ? checkmark_image : xmark_image %> (<%=h @entity.scoped_reason %>)</li>
       <li>Hidden: <%= @entity.hidden ? checkmark_image : xmark_image %></li>
     </ul>
 

--- a/app/views/entities/index.erb
+++ b/app/views/entities/index.erb
@@ -34,6 +34,7 @@
             <tr>
               <th>name</th>
               <th>details</th>
+              <th>enriched</th>
               <th>scoped</th>
             </tr>
           </thead>
@@ -62,12 +63,19 @@
                     </ul>
                   </td>
                   <td>
-                    <ul>
-                    <% grouped_entities.each do |e| %>
-                      <li><%= e.scoped ? checkmark_image : xmark_image %> </li>
-                    <% end %>
-                    </ul>
-                  </td>
+                  <ul>
+                  <% grouped_entities.each do |e| %>
+                    <li><%= e.enriched ? checkmark_image : xmark_image %> </li>
+                  <% end %>
+                  </ul>
+                </td>
+                <td>
+                <ul>
+                  <% grouped_entities.each do |e| %>
+                    <li><%= e.scoped ? checkmark_image : xmark_image %> </li>
+                  <% end %>
+                </ul>
+              </td>
                 </tr>
               <% end %>
             
@@ -77,6 +85,11 @@
               <tr class="transparent-table">
                 <td><a href="/<%=h @project_name%>/entities/<%=e.id%>"> <%= h e %> </a></td>
                 <td><%= h e.detail_string %></td>
+                <td>
+                  <div class='td-images'>
+                    <%=  e.enriched ? checkmark_image : xmark_image %>
+                  </div>
+                </td>
                 <td>
                   <div class='td-images'>
                     <%=  e.scoped ? checkmark_image : xmark_image %>

--- a/data/standard_name_exceptions.list
+++ b/data/standard_name_exceptions.list
@@ -173,6 +173,9 @@
 /^.*\.silverpop.com(:[0-9]*)?$/
 /^.*\.splashthatd.com(:[0-9]*)?$/
 /^.*\.squarespace.com(:[0-9]*)?$/
+/^.*\.squarespace-mail.com(:[0-9]*)?$/
+/^.*\.sqspcdn.com(:[0-9]*)?$/
+/^.*\.sqsp.net(:[0-9]*)?$/
 /^.*\.statuscake.io(:[0-9]*)?$/
 /^.*\.statuspage.io(:[0-9]*)?$/
 /^.*\.statusio.com(:[0-9]*)?$/

--- a/lib/entities/api_endpoint.rb
+++ b/lib/entities/api_endpoint.rb
@@ -51,6 +51,15 @@ class ApiEndpoint < Intrigue::Core::Model::Entity
     ["enrich/api_endpoint"]
   end
 
+  def scope_verification_list
+    [
+      { type_string: self.type_string, name: self.name },
+      { type_string: "DnsRecord", name:  URI.parse(self.name).host },
+      { type_string: "Domain", name:  parse_domain_name(URI.parse(self.name).host) }
+    ]
+  end
+
+
 end
 end
 end

--- a/lib/entities/dns_record.rb
+++ b/lib/entities/dns_record.rb
@@ -36,10 +36,6 @@ class DnsRecord < Intrigue::Core::Model::Entity
     return true if self.allow_list
     return false if self.deny_list
 
-    # Check the domain
-    domain_name = parse_domain_name(self.name)
-    return true if self.project.allow_list_entity?("Domain", domain_name)
-
   # if we didnt match the above and we were asked, default to false
   false
   end

--- a/lib/entities/domain.rb
+++ b/lib/entities/domain.rb
@@ -2,6 +2,7 @@ module Intrigue
 module Entity
 class Domain < Intrigue::Core::Model::Entity
 
+
   def self.metadata
     {
       :name => "Domain",

--- a/lib/entities/email_address.rb
+++ b/lib/entities/email_address.rb
@@ -2,7 +2,7 @@ module Intrigue
 module Entity
 class EmailAddress < Intrigue::Core::Model::Entity
 
-  include Intrigue::Task::Dns
+
 
   def self.metadata
     {
@@ -21,10 +21,6 @@ class EmailAddress < Intrigue::Core::Model::Entity
     details["origin"] if details && details["origin"]
   end
 
-  def enrichment_tasks
-    ["enrich/email_address"]
-  end
-
   ###
   ### SCOPING
   ###
@@ -38,6 +34,17 @@ class EmailAddress < Intrigue::Core::Model::Entity
     return true if self.project.allow_list_entity?("Domain", domain_name)
 
   false
+  end
+
+  def enrichment_tasks
+    ["enrich/email_address"]
+  end
+
+  def scope_verification_list
+    [
+      { type_string: self.type_string, name: self.name },
+      { type_string: "Domain", name:  "#{self.name}".split("@").last }
+    ]
   end
 
 

--- a/lib/entities/email_address.rb
+++ b/lib/entities/email_address.rb
@@ -2,8 +2,6 @@ module Intrigue
 module Entity
 class EmailAddress < Intrigue::Core::Model::Entity
 
-
-
   def self.metadata
     {
       :name => "EmailAddress",
@@ -28,10 +26,6 @@ class EmailAddress < Intrigue::Core::Model::Entity
     return true if scoped
     return true if self.allow_list
     return false if self.deny_list
-
-    # Check the domain
-    domain_name = self.name.split("@").last
-    return true if self.project.allow_list_entity?("Domain", domain_name)
 
   false
   end

--- a/lib/entities/ip_address.rb
+++ b/lib/entities/ip_address.rb
@@ -50,8 +50,8 @@ class IpAddress < Intrigue::Core::Model::Entity
     return true if created_by?("masscan_scan")
     return true if created_by?("nmap_scan")
 
-    # if we have aliases and theyre scoped, we can scope us
-    #return false if aliases && aliases.select{ |x| !x.scoped }.count > 0
+    # while it might be nice to scope out stuff on third paries, we still need 
+    # to keep it in to scan, as we'll want all associated URLs
 
   # if we didnt match the above and we were asked, default to true as we'll
   #  we'll want to scope things in before we have a full set of aliases (?)

--- a/lib/entities/ip_address.rb
+++ b/lib/entities/ip_address.rb
@@ -51,7 +51,7 @@ class IpAddress < Intrigue::Core::Model::Entity
     return true if created_by?("nmap_scan")
 
     # if we have aliases and theyre scoped, we can scope us
-    #return false if aliases && aliases.select{ |x| !x.scoped? }.count > 0
+    #return false if aliases && aliases.select{ |x| !x.scoped }.count > 0
 
   # if we didnt match the above and we were asked, default to true as we'll
   #  we'll want to scope things in before we have a full set of aliases (?)

--- a/lib/entities/mailserver.rb
+++ b/lib/entities/mailserver.rb
@@ -33,6 +33,14 @@ class Mailserver < Intrigue::Core::Model::Entity
   false
   end
 
+  def scope_verification_list
+    [
+      { type_string: self.type_string, name: self.name },
+      { type_string: "DnsRecord", name:  self.name },
+      { type_string: "Domain", name:  parse_domain_name(self.name) }
+    ]
+  end
+  
 end
 end
 end

--- a/lib/entities/nameserver.rb
+++ b/lib/entities/nameserver.rb
@@ -33,6 +33,15 @@ class Nameserver < Intrigue::Core::Model::Entity
   false
   end
 
+  def scope_verification_list
+    [
+      { type_string: self.type_string, name: self.name },
+      { type_string: "DnsRecord", name:  self.name },
+      { type_string: "Domain", name:  parse_domain_name(self.name) }
+    ]
+  end
+
+
 end
 end
 end

--- a/lib/entities/network_service.rb
+++ b/lib/entities/network_service.rb
@@ -36,6 +36,13 @@ class NetworkService < Intrigue::Core::Model::Entity
   true
   end
 
+  def scope_verification_list
+    [
+      { type_string: self.type_string, name: self.name },
+      { type_string: "IpAddress", name:  self.name.split(":").first }
+    ]
+  end
+
 end
 end
 end

--- a/lib/entities/uri.rb
+++ b/lib/entities/uri.rb
@@ -47,6 +47,21 @@ class Uri < Intrigue::Core::Model::Entity
     # only scope in stuff that's not hidden (hnm, is this still needed?)
     return false if self.hidden
 
+    ###
+    ### These should move to ident and set the hidden attribute 
+    ### 
+    shared_infra_titles = [
+      "404 Not Found",
+      "404 Vhost unknown", # http://217.70.185.65:80
+      "Google",
+      "Not Found Medium", # https://52.1.147.205:443
+      "Sign in to Outlook", # http://40.97.160.2:80
+      "Sign in to your account", # https://104.47.55.138:443
+    ]
+
+    return false if "#{URI.parse(self.name).host}".is_ip_address? && 
+      shared_infra_titles.include?(self.get_detail("title"))
+
   # if we didnt match the above and we were asked, it's still true
   true
   end

--- a/lib/entities/uri.rb
+++ b/lib/entities/uri.rb
@@ -47,22 +47,20 @@ class Uri < Intrigue::Core::Model::Entity
     # only scope in stuff that's not hidden (hnm, is this still needed?)
     return false if self.hidden
 
-    # grab the URL, parse it and get the hostname. Check if this hostname is 
-    # in the deny list... this will stop stuff like sites for known top level domain https://hosting-company.com
-    # from becoming scoped, but keeps us from missing stuff that like https://company.hosting-company.com
-    uri = URI.parse(self.name)
-    hostname = uri.hostname
-    # note - this may not be a domain, but that's okay, we only want to search 'Domain'.
-    if !self.project.traversable_entity?("Domain", hostname) 
-      return false
-    end
-
   # if we didnt match the above and we were asked, it's still true
   true
   end
 
   def enrichment_tasks
     ["enrich/uri"]
+  end
+
+  def scope_verification_list
+    [
+      { type_string: self.type_string, name: self.name },
+      { type_string: "DnsRecord", name:  URI.parse(self.name).host },
+      { type_string: "Domain", name:  parse_domain_name(URI.parse(self.name).host) }
+    ]
   end
 
 end

--- a/lib/entity_manager.rb
+++ b/lib/entity_manager.rb
@@ -19,7 +19,7 @@ class EntityManager
 
     #note this will be nil if we didn't match
     unless matches.first
-      raise "Unable to match to a known entity. Failing on #{type_string}."
+      raise InvalidEntityError, "Unable to match to a known entity. Failing on #{type_string}."
     end
 
   # only return the first (and best) match
@@ -155,43 +155,54 @@ class EntityManager
       # Create a new entity, validating the attributes
       type = resolve_type_from_string(type_string)
 
-      allowed_list = project.allow_list_entity?(type_string, downcased_name)
-      denied_list = project.deny_list_entity?(type_string, downcased_name)
-
-      entity_details = {
+      base_entity_details = {
         :name => downcased_name,
         :project_id => project.id,
         :type => type.to_s,
-        :details => details,
-        :allow_list => allowed_list,
-        :deny_list => denied_list,
-        :traversable => project.traversable_entity?(type_string, downcased_name) ? true : false, 
-        :hidden => (project.traversable_entity?(type_string, downcased_name) ? false : true )
+        :details => details
       }
 
       # handle alias group
       if primary_entity
-        entity_details[:alias_group_id] = primary_entity.alias_group_id
+        base_entity_details[:alias_group_id] = primary_entity.alias_group_id
       else
         g = Intrigue::Core::Model::AliasGroup.create(:project_id => project.id)
-        entity_details[:alias_group_id] = g.id
+        base_entity_details[:alias_group_id] = g.id
       end
 
       begin
         # Create a new entity in that group
         entity = Intrigue::Core::Model::Entity.update_or_create(
-          {name: downcased_name, type: type.to_s, project: project}, entity_details)
+          {name: downcased_name, type: type.to_s, project: project}, base_entity_details)
 
         unless entity
-          tr.log_fatal "Unable to create entity: #{entity_details}"
+          tr.log_fatal "Unable to create entity: #{base_entity_details}"
           return nil
         end
 
+
+        # 
+        # ok, now let's add the contextual attributes which will 
+        # help us understand how to manage this going forward, primarily
+        # as it pertains to scoping.
+        # 
+        # allow_list
+        # deny_list
+        # traversable
+        # hidden
+        # 
+        entity.allow_list = project.allow_list_entity?(entity)
+        entity.deny_list = project.deny_list_entity?(entity)
+        entity.traversable = project.traversable_entity?(entity)
+        entity.hidden = !traversable
+        entity.save_changes
+
+
       rescue Encoding::UndefinedConversionError => e
-        tr.log_fatal "Unable to create entity:#{entity_details}\n #{e}"
+        tr.log_fatal "Unable to create entity:#{base_entity_details}\n #{e}"
         return nil
       rescue Sequel::DatabaseError => e
-        tr.log_fatal "Unable to create entity:#{entity_details}\n #{e}"
+        tr.log_fatal "Unable to create entity:#{base_entity_details}\n #{e}"
         return nil
       end
 
@@ -218,13 +229,11 @@ class EntityManager
         raise InvalidEntityError.new("Invalid entity, unable to validate: #{type_string}##{downcased_name}")
       end
 
-      ###
-      ### make a connection to the task result on the first one
-      ###
-      tr.add_entity(entity)
-
+    ###
+    ### make a connection to the task result on the first one
+    ###
+    tr.add_entity(entity)
     end
-
 
     ###
     ### Always stick the task name on the entity 
@@ -232,9 +241,10 @@ class EntityManager
     task_list = (entity.get_detail("source_task_list") || []) << tr.name
     entity.set_detail "source_task_list", task_list
 
-
     ###
-    ### SCOPING MUST ALWAYS RE-RUN
+    ### Scoping must always run, because the task run we're inside may have 
+    ### auto_scope = true .. or the entity may have been created with an attribute
+    ### that specifies how we should be scopoed
     ###
 
     #####
@@ -263,6 +273,7 @@ class EntityManager
     # note that we delete the detail since we no longer need it
     # TODO... is this used today?
     if (details["scoped"] == true || details["scoped"] == "true")
+
       tr.log "Entity was specifically requested to be scoped"
       details = details.tap{ |h| h.delete("scoped") }
       scope_request = "true"
@@ -304,16 +315,16 @@ class EntityManager
     #####
 
     # ENRICHMENT LAUNCH (this may re-run if an entity has just been scoped in
-    if !entity.deny_list && !tr.autoscheduled # manally scheuduled, automatically enrich 
+    if !tr.autoscheduled && !entity.deny_list # manally scheuduled, automatically enrich 
 
-      if entity.enriched
+      if entity.enriched?
         tr.log "Re-scheduling enrichment for existing entity (manually run)!"
       end
 
       tr.log "Manually scheduling enrich: #{entity.name}"
       entity.enrich(tr)
 
-    elsif !entity.deny_list && tr.auto_enrich && (!entity_already_existed || project.allow_reenrich)
+    elsif tr.auto_enrich && !entity.deny_list && (!entity_already_existed || project.allow_reenrich)
       
       # Check if we've already run first and return gracefully if so
       if entity.enriched && !project.allow_reenrich

--- a/lib/entity_manager.rb
+++ b/lib/entity_manager.rb
@@ -193,7 +193,8 @@ class EntityManager
         # 
         entity.allow_list = project.allow_list_entity?(entity)
         entity.deny_list = project.deny_list_entity?(entity)
-        entity.traversable = project.traversable_entity?(entity)
+        traversable = project.traversable_entity?(entity)
+        entity.traversable = traversable
         entity.hidden = !traversable
         entity.save_changes
 
@@ -207,7 +208,7 @@ class EntityManager
       end
 
       # necessary to relookup?
-      entity = Intrigue::Core::Model::Entity.first(id: entity.id)
+      entity = Intrigue::Core::Model::Entity.last(id: entity.id)
 
       ### Ensure we have an entity
       unless entity

--- a/lib/system/bootstrap.rb
+++ b/lib/system/bootstrap.rb
@@ -56,13 +56,6 @@ module Bootstrap
       project.use_standard_exceptions = p["use_standard_exceptions"] || true
 
       project.allowed_namespaces = p["allowed_namespaces"]
-
-      # in the case where this is [], we want this to be handled like 
-      # anything that's claimed as a standard or global exception, so let's 
-      # just set our project name as the default ... TODO... hosted service 
-      # should also behave like this?
-      project.allowed_namespaces = [project.name] if project.allowed_namespaces == []
-
       project.uuid = p["collection_run_uuid"]
       project.save 
 
@@ -71,7 +64,6 @@ module Bootstrap
       if config["additional_exception_list"]
         _add_no_traverse_entities(project.id, config["additional_exception_list"].sort.to_a)
       end
-      puts "Done!"
 
       # parse up the seeds
       parsed_seeds = p["seeds"].map{|s| _parse_entity s["entity"] }

--- a/lib/system/bootstrap.rb
+++ b/lib/system/bootstrap.rb
@@ -54,7 +54,15 @@ module Bootstrap
       end
       
       project.use_standard_exceptions = p["use_standard_exceptions"] || true
-      project.allowed_namespaces = p["allowed_namespaces"] || []
+
+      project.allowed_namespaces = p["allowed_namespaces"]
+
+      # in the case where this is [], we want this to be handled like 
+      # anything that's claimed as a standard or global exception, so let's 
+      # just set our project name as the default ... TODO... hosted service 
+      # should also behave like this?
+      project.allowed_namespaces = [project.name] if project.allowed_namespaces == []
+
       project.uuid = p["collection_run_uuid"]
       project.save 
 

--- a/lib/tasks/base.rb
+++ b/lib/tasks/base.rb
@@ -208,15 +208,13 @@ class BaseTask
         @entity.save_changes 
 
         ### AND WE CAN DECIDE SCOPE BASED ON COMPLETE ENTITY (unless we were already scoped in!)
-        if check_scope = @entity.scoped?
-          @entity.set_scoped!(check_scope, "entity_scoping_rules") #always fall back to our entity-specific logic if there was no request
-          #_log_good "POST-ENRICH AUTOMATED ENTITY SCOPE: #{@entity.scoped}"
-        end
-        
+        ### .. always fall back to our entity-specific logic if there was no request
+        @entity.set_scoped!(@entity.scoped?, "entity_scoping_rules") 
+      
         ###
         ## NOW, KICK OFF WORKFLOWS for SCOPED ENTiTIES ONLY
         ###
-        if @entity.scoped?
+        if @entity.scoped
 
           # WORKFLOW LAUNCH (ONLY IF WE ARE ATTACHED TO A WORKFLOW) 
           # if this is part of a scan and we're in depth
@@ -233,6 +231,7 @@ class BaseTask
             ## 
             ## Start the workflow!
             ##
+            puts "LAUNCHING WORKFLOW on #{@entity.name} after #{@task_result.name}"
             workflow.start(@entity, @task_result)
 
           else

--- a/spec/entity_manager_spec.rb
+++ b/spec/entity_manager_spec.rb
@@ -1,0 +1,55 @@
+require_relative 'spec_helper'
+
+describe "Intrigue" do
+describe "EntityManager" do
+
+  #https://relishapp.com/rspec/rspec-core/v/2-0/docs/hooks/before-and-after-hooks
+#https://relishapp.com/rspec/rspec-core/v/2-0/docs/hooks/before-and-after-hooks
+before(:each) do
+  # project 
+  @p = Intrigue::Core::Model::Project.update_or_create(name: "test")
+end
+
+after(:each) do
+  @p.delete!
+end
+
+  it "should successfully create a well-formed new entity"  do 
+    e = Intrigue::EntityManager.create_first_entity "test", "Domain", "test.com", {}
+    expect(e).to be_kind_of(Intrigue::Entity::Domain)
+  end
+
+  it "should fail to successfully create an ill-formed new entity"  do 
+    e = Intrigue::EntityManager.create_first_entity "test", "Domain", "!!!!bad!.com", {}
+    expect(e).to be(nil)
+  end
+
+  it "should successfully merge an entity"  do 
+
+    # create a logger 
+    l = Intrigue::Core::Model::Logger.create( project_id: @p.id)
+    
+    # now create the base entity 
+    e1 = Intrigue::EntityManager.create_first_entity "test", "Domain", "test.com", {"foo" => "bar"}
+
+    t = Intrigue::Core::Model::TaskResult.create(
+      name: "test_task", project_id: @p.id, logger_id: l.id, base_entity_id: e1.id )
+
+    e2 = Intrigue::EntityManager.create_or_merge_entity t.id, "Domain", "test.com", {"baz" => "bar"}
+
+    expect(e2.details.to_h).to be_kind_of(Hash)
+    expect(e2.details).to have_key("source_task_list")
+    expect(e2.details).to have_key("foo")
+    expect(e2.details).to have_key("baz")
+    
+
+  end
+
+  #it "should successfully create a second entity"  do 
+  #  e = Intrigue::EntityManager.create_or_merge "test", "Domain", "!!!!bad!.com", {}
+  #  expect(e).to be(nil)
+  #end
+
+
+end
+end

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -53,7 +53,6 @@ describe "Entity" do
     expect(@p.traversable_entity?(@e)).to eq(true)
   end 
 
-
   it "will find alreadyclaimed.com not traversable since it is not in an allowed namespace" do
     
     # create the entity 

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -12,13 +12,13 @@ describe "Entity" do
     @ge2 = Intrigue::Core::Model::GlobalEntity.update_or_create type: "Domain", name: "alreadyclaimed.com", namespace: "BBB"
     
     # project 
-    @p = Intrigue::Core::Model::Project.update_or_create(name: "test")
+    @p = Intrigue::Core::Model::Project.update_or_create(name: "testx")
     
     # entity 
     typex = "Intrigue::Entity::Domain"
     namex = "test.com"
-    Intrigue::Core::Model::Entity.update_or_create(project: @p, type: typex, name: namex)
-    @e = Intrigue::Core::Model::Entity.first type: typex, name: namex   
+    Intrigue::Core::Model::Entity.update_or_create(project_id: @p.id, type: typex, name: namex)
+    @e = Intrigue::Core::Model::Entity.last type: typex, name: namex   
 
     # alias groups 
     @ag = Intrigue::Core::Model::AliasGroup.update_or_create(project_id: @p.id, name: "xyz");
@@ -28,25 +28,33 @@ describe "Entity" do
   after(:each) do  
     @ge1.delete
     @ge2.delete
+    
+    # deletes all the things associated with the project
     @p.delete!
   end
 
   it "can be created" do
-    expect(@e.project.name).to eq("AAA")
     expect(@e.name).to eq("test.com")
+    expect(@e.project.name).to eq("testx")
   end
 
   it "can be added to an entity group" do
     @ag.add_entity @e;
     expect(@ag.name).to eq("xyz")
+    expect(@ag.entities.first.id).to eq(@e.id)
     # TODO... more verification needed here 
   end
 
-  it "will find test.com traversable" do
+  it "will find test.com traversable since there is no namespace associated" do
     expect(@p.traversable_entity?(@e)).to eq(true)
   end 
 
-  it "will find alreadyclaimed.com not traversable" do
+  it "will find test.com traversable since there is no namespace associated" do
+    expect(@p.traversable_entity?(@e)).to eq(true)
+  end 
+
+
+  it "will find alreadyclaimed.com not traversable since it is not in an allowed namespace" do
     
     # create the entity 
     t = "Intrigue::Entity::Domain"

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -5,43 +5,73 @@ describe "Models" do
 describe "Entity" do
 
   #https://relishapp.com/rspec/rspec-core/v/2-0/docs/hooks/before-and-after-hooks
-  before(:all) do 
-    Intrigue::Core::Model::GlobalEntity.create type: "Intrigue::Entity::Domain", name: "test.com", namespace: "test"
-    @p = Intrigue::Core::Model::Project.create :name => "test"
+  before(:each) do 
+    
+    # global entities
+    @ge1 = Intrigue::Core::Model::GlobalEntity.update_or_create type: "Domain", name: "test.com", namespace: "AAA"
+    @ge2 = Intrigue::Core::Model::GlobalEntity.update_or_create type: "Domain", name: "alreadyclaimed.com", namespace: "BBB"
+    
+    # project 
+    @p = Intrigue::Core::Model::Project.update_or_create(name: "test")
+    
+    # entity 
+    typex = "Intrigue::Entity::Domain"
+    namex = "test.com"
+    Intrigue::Core::Model::Entity.update_or_create(project: @p, type: typex, name: namex)
+    @e = Intrigue::Core::Model::Entity.first type: typex, name: namex   
+
+    # alias groups 
+    @ag = Intrigue::Core::Model::AliasGroup.update_or_create(project_id: @p.id, name: "xyz");
+
   end
 
-  after(:all) do 
-    Intrigue::Core::Model::GlobalEntity.truncate
-    Intrigue::Core::Model::Project.truncate 
+  after(:each) do  
+    @ge1.delete
+    @ge2.delete
+    @p.delete!
   end
 
   it "can be created" do
-    entity = Intrigue::Core::Model::Entity.create({
-        :project => @p,
-        :type => "Intrigue::Core::Model::String",
-        :name => "test"})
-
-    expect(entity.name).to eq("test")
-    expect(entity.project.name).to eq("test")
+    expect(@e.project.name).to eq("AAA")
+    expect(@e.name).to eq("test.com")
   end
 
   it "can be added to an entity group" do
-    e = Intrigue::Core::Model::Entity.create(:project => @p, :type => "Intrigue::Entity::String", :name => "z")
-    g = Intrigue::Core::Model::AliasGroup.create(:project => @p, :name=>"xyz"); g.save
-    g.add_entity e;
-
-    expect(g.name).to eq("xyz")
-    #expect(g.entities.include?(e)).to be true
+    @ag.add_entity @e;
+    expect(@ag.name).to eq("xyz")
+    # TODO... more verification needed here 
   end
 
-
   it "will find test.com traversable" do
-    e = Intrigue::Core::Model::Entity.create(project: @p, type: "Intrigue::Entity::Domain", name: "test.com")
-    @p.traversable_entity?(e.type_string, e.name)
+    expect(@p.traversable_entity?(@e)).to eq(true)
   end 
 
+  it "will find alreadyclaimed.com not traversable" do
+    
+    # create the entity 
+    t = "Intrigue::Entity::Domain"
+    s = "alreadyclaimed.com"
+    e = Intrigue::Core::Model::Entity.new({
+      project_id: @p.id, 
+      type: t, 
+      name: s
+    })
+    e.save
 
+    @p.allowed_namespaces = ["invalid"]
+    @p.save
 
+    e = Intrigue::Core::Model::Entity.first type: t, name: s    
+
+    expect(@p.allow_list_entity?(e)).to eq(false)
+    expect(@p.deny_list_entity?(e)).to eq(true)
+    expect(@p.traversable_entity?(e)).to eq(false)
+  end
+
+  #it "should find google out of scope" do
+  #  e = Intrigue::Core::Model::Entity.create(
+  #    project_id: @p.id, type: "Domain", name: "google.com")
+  #end
 
 end
 end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,0 +1,26 @@
+require_relative 'spec_helper'
+
+describe "Intrigue" do
+describe "Models" do
+describe "Project" do
+
+  #https://relishapp.com/rspec/rspec-core/v/2-0/docs/hooks/before-and-after-hooks
+  before(:all) do 
+    @p = Intrigue::Core::Model::Project.create(name: "test")
+  end
+
+  after(:all) do 
+    Intrigue::Core::Model::Project.truncate 
+  end
+
+  it "can be created" do
+    expect(@p.name).to eq("test")
+  end
+
+  it "can be deleted" do
+    expect(@p.delete!).to eq(true)
+  end
+
+end
+end
+end


### PR DESCRIPTION
This check makes a number of improvements to scoping logic, and overall, attempts to simplify the process thorough a refactor. Specific changes: 
  - get rid of on demand check allow_list, deny_list methods on the entity, these are stored types
  - allow_list_entity? and deny_list_entity on project should take the short type (Domain vs Intrigue::Entity::Domain)
  - each entity should transform into its a scope_verification_list ...
  - url should tranform into hostname and domain, as should email address
  - allows_list_entity and deny_list_entity should both traverse each item in the list
  - define verifiable types on GlobalEntity
  - allow_list_entity? and deny_list_entity? should take an entity and be called after entity created
  - include Intrigue::Core::System::DnsHelpers, include Intrigue::Core::System::Validations as part of entity
  - move to type_string for global entities
  - project tests pass
  - ensure types are being imported from global entity well
  - entity tests pass
  - alias group shoudl be removed when project is destroyed
  - tests for creatE_first_entity
  - tests for create_or_merge_entity
  - make sure that matching for globals is correct