### PR TITLE
Vagrant setup encourage the user to use development tools (foreman vs intriguectl / god)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,9 @@ Vagrant.configure("2") do |config|
   config.vm.define "intrigue-core" do |x|
 
     # install all deps 
-    x.vm.provision :shell, privileged: false, path: "util/bootstrap.sh"
+    x.vm.provision :shell, privileged: false, inline: <<-SHELL
+      /home/ubuntu/util/bootstrap.sh development
+    SHELL
 
     # run setup and start the service
     x.vm.provision "shell", privileged: false, inline: <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,21 +5,20 @@ Vagrant.configure("2") do |config|
 
     # install all deps 
     x.vm.provision :shell, privileged: false, inline: <<-SHELL
-      /home/ubuntu/util/bootstrap.sh development
+      ~/core/util/bootstrap.sh development
     SHELL
 
     # run setup and start the service
     x.vm.provision "shell", privileged: false, inline: <<-SHELL
-      cd /home/ubuntu/core
-      sudo -u postgres createuser intrigue -s
-      sudo -u postgres createdb intrigue_dev
+      source ~/.bash_profile
+      cd ~/core
       bundle install
-      bundle exec setup
+      bundle exec rake setup
       bundle exec rake db:migrate
       foreman start
     SHELL
  
-    x.vm.synced_folder ".", "/home/ubuntu/core"
+    x.vm.synced_folder ".", "/home/vagrant/core"
     x.vm.hostname = "intrigue-core"
     x.vm.network :private_network, ip: "10.0.0.10"
     x.vm.network "forwarded_port", guest: 7777, host: 7777

--- a/util/README
+++ b/util/README
@@ -1,5 +1,0 @@
-                      Welcome to Intrigue Core!
-
-Please file bugs & requests here: https://github.com/intrigueio/intrigue-core/issues
-
-Other comments? Questions? Email hello@intrigue.io.

--- a/util/bootstrap.sh
+++ b/util/bootstrap.sh
@@ -352,6 +352,9 @@ sudo apt-get -y clean
 ###
 if [ "$BOOTSTRAP_ENV" == "production" ] && !$(grep -q intriguectl ~/.bash_profile); then
 
+  echo "echo \"Welcome to Intrigue Core! For help, join the community at https://core.intrigue.io\"" >> ~/.bash_profile
+  echo "echo \"\"" >> ~/.bash_profile
+
   # add welcome message
   echo "[+] Adding intrigue to path"
   ln -s ~/core/util/intriguectl ~/go/bin/intriguectl 2> /dev/null

--- a/util/bootstrap.sh
+++ b/util/bootstrap.sh
@@ -5,6 +5,14 @@
 #####
 
 # if these are already set by our parent, use that.. otherwise sensible defaults
+if [ "$1" == "development" ]; then
+  echo "Dev Bootstrap Starting!"; 
+  BOOTSTRAP_ENV=development
+else 
+  echo "Production Bootstrap Starting!";
+  BOOTSTRAP_ENV=production
+fi 
+
 export INTRIGUE_DIRECTORY="${IDIR:=/home/$USER/core}"
 export RUBY_VERSION="${RUBY_VERSION:=2.7.2}"
 export DEBIAN_FRONTEND=noninteractive
@@ -256,7 +264,6 @@ echo "enable memory overcommit"
 sudo bash -c "echo vm.overcommit_memory=0 >> /etc/sysctl.conf"
 sudo sysctl -p
 
-
 echo "Bumping ulimit file/proc settings in /etc/security/limits.conf"
 sudo bash -c "echo 'root hard nofile 524288' >> /etc/security/limits.conf"
 sudo bash -c "echo 'root soft nofile 524288' >> /etc/security/limits.conf"
@@ -336,24 +343,23 @@ cd $INTRIGUE_DIRECTORY
 bundle update --bundler
 bundle install
 
-# TOOD ... remove this on next major release
-echo "[+] Intrigue services exist, removing... (ec2 legacy)"
-if [ ! -f /etc/init.d/intrigue ]; then
-  rm -rf /etc/init.d/intrigue
-fi
-
 # Cleaning up
 echo "[+] Cleaning up packages!"
 sudo apt-get -y clean
 
-# add welcome message
-if ! $(grep -q intriguectl ~/.bash_profile); then
-  echo "[+] Configuring startup message"
-  echo "boxes -a c $INTRIGUE_DIRECTORY/util/README" >> ~/.bash_profile
-  echo "echo \"\"" >> ~/.bash_profile
+###
+### Only in production should we continue on to do this
+###
+if [ "$BOOTSTRAP_ENV" == "production" ] && !$(grep -q intriguectl ~/.bash_profile); then
 
+  # add welcome message
   echo "[+] Adding intrigue to path"
-  echo "ln -s ~/core/util/intriguectl ~/go/bin/intriguectl 2> /dev/null" >> ~/.bash_profile
+  ln -s ~/core/util/intriguectl ~/go/bin/intriguectl 2> /dev/null
+  
+  # always tell the user they have intriguectl 
   echo "intriguectl" >> ~/.bash_profile
+
+else
+  echo "echo \"CORE DEVEOPMENT ENVIRONMENT! Use foreman to manage services!\"" >> ~/.bash_profile  
 fi
 


### PR DESCRIPTION
This PR attempts to make a development environment a little more explicit by removing a few of the commands at the end of the bootstrap that are prod-only. We can probably improve by sending the user to https://github.com/intrigueio/intrigue-core/wiki/Setting-up-a-Development-Environment-%28on-Ubuntu%2C-Kali%2C-Debian%29 when it completes (or something). 

Additionally, this makes a change to the Vagrantfile that passes the 'development' parameter, indicating that this behavior should be selected. 

This is currently untested. Pushing it up since @tiptone ran into a few issues here.  