### PR TITLE
fix check so it does not always return true

### DIFF
--- a/lib/tasks/enrich/network_service.rb
+++ b/lib/tasks/enrich/network_service.rb
@@ -114,7 +114,7 @@ class NetworkService < Intrigue::Task::BaseTask
       { port: 2095, net_name: "GOOGLE, US", cpe: "cpe:2.3::generic:connection_reset_(attempted_http_connection)::"  }, 
       { port: 25, net_name: "GOOGLE, US" }
     ]
-    if known_ports.find{ |x| x[:port] == port && x[:net_name] == net_name }
+    if !known_ports.select{ |x| x[:port] == port && x[:net_name] == net_name }.empty?
       hide_reason = "Matched known hidden service"
       hide_value = true 
     end


### PR DESCRIPTION
By testing other stuff i learned that the check:
```
if known_ports.find{ |x| x[:port] == port && x[:net_name] == net_name }
      hide_reason = "Matched known hidden service"
      hide_value = true 
end
```
would always evaluate to `true` and run the code inside the if statement. As a result, all NetworkServices entities were being marked hidden. I tested this PR for the negative case, and it correctly does **not** mark an entity hidden when net_name doesn't match known values. I was unable to find an entity for the positive use case.