### PR TITLE
support for transformations before creating entity

### DIFF
--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -142,6 +142,11 @@ module Model
       ]
     end
 
+    # override me... see: lib/entities/domain.rb
+    def self.transform_before_save(name, details)
+      return name, details
+    end
+    
     # override me... see: lib/entities/aws_credential.rb
     def transform!
       true

--- a/lib/entities/dns_record.rb
+++ b/lib/entities/dns_record.rb
@@ -13,6 +13,12 @@ class DnsRecord < Intrigue::Core::Model::Entity
     }
   end
 
+  # gets called before entity is created
+  def self.transform_before_save(name, details_hash)
+    name = SimpleIDN.to_ascii(name)
+    return name, details_hash
+  end
+
   def validate_entity
     name.match dns_regex(true)
   end

--- a/lib/entities/domain.rb
+++ b/lib/entities/domain.rb
@@ -12,6 +12,12 @@ class Domain < Intrigue::Core::Model::Entity
     }
   end
 
+  # gets called before entity is created
+  def self.transform_before_save(name, details_hash)
+    name = SimpleIDN.to_ascii(name)
+    return name, details_hash
+  end
+  
   def validate_entity
     name.match dns_regex(true)
   end

--- a/lib/entity_manager.rb
+++ b/lib/entity_manager.rb
@@ -80,6 +80,8 @@ class EntityManager
     else
       # Create a new entity, validating the attributes
       type = resolve_type_from_string(type_string)
+      # execure "before" transformations before entity is created
+      downcased_name, details_hash = type.transform_before_save(downcased_name, details_hash)
       g = Intrigue::Core::Model::AliasGroup.create(:project_id => project.id)
       entity = Intrigue::Core::Model::Entity.create({
         name: downcased_name,
@@ -148,6 +150,8 @@ class EntityManager
 
       # Create a new entity, validating the attributes
       type = resolve_type_from_string(type_string)
+      # execure "before" transformations before entity is created
+      downcased_name, details_hash = type.transform_before_save(downcased_name, details_hash)
 
       # handle alias group
       if primary_entity


### PR DESCRIPTION
This PR creates support for applying transformations to the entity `name` and `details_hash`. Since this runs _before_ the entity is created, the values are passed as parameters and returned back. 

This new functionality has been immediately applied to `domain` and `dns_record` entities, to support punycode domains.