### PR TITLE
issue factory shouldnt return issues with no check

### DIFF
--- a/lib/issue_factory.rb
+++ b/lib/issue_factory.rb
@@ -71,12 +71,17 @@ module Intrigue
         self.issues.each do |h| 
           # generate the instances
           hi = h.generate({}); 
-          # then geet all instaces of affected software with issues names
+          # then get all instaces of affected software with issues names
           as = (hi[:affected_software] || [])
           mapped_issues << as.map{|x| x.merge({ :check => (hi[:check]||hi[:name]) }) }
         end
+
+
+        ## pull out only items that have an affected software that matches our 
+        ## passed-in vendor / product and only return the name of the task/check to be run 
+        tasks_or_checks = mapped_issues.flatten.select{|x| x[:vendor] == vendor && x[:product] == product}.map{|x| x[:check]}
     
-      mapped_issues.flatten.select{|x| x[:vendor] == vendor && x[:product] == product}.map{|x| x[:check] }.uniq.compact
+      tasks_or_checks.map{|x| x if Intrigue::TaskFactory.include?(x)}.uniq.compact
       end
     
       #

--- a/spec/issue_factory_spec.rb
+++ b/spec/issue_factory_spec.rb
@@ -1,0 +1,25 @@
+require_relative 'spec_helper'
+
+describe "Intrigue" do
+describe "Issue" do
+describe "IssueFactory" do
+
+  it "will parse dns records from web content" do
+
+    # []
+    checks_or_tasks = Intrigue::Issue::IssueFactory.checks_for_vendor_product "PHP", "PHP"
+    expect(checks_or_tasks).to be_empty
+
+    # ["liferay_portal_cve_2020_7961"]
+    checks_or_tasks = Intrigue::Issue::IssueFactory.checks_for_vendor_product "Liferay", "Liferay Portal"
+    expect(checks_or_tasks).to include("liferay_portal_cve_2020_7961")
+
+    # => ["uri_brute_focused_content"]
+    checks_or_tasks = Intrigue::Issue::IssueFactory.checks_for_vendor_product "Microsoft", "ASP.NET"
+    expect(checks_or_tasks).to include("uri_brute_focused_content")
+    
+  end
+
+end
+end
+end


### PR DESCRIPTION
currently it'll return issues w/o a check due to the way it selects the list, resulting in a non-runnable item being returned. this addresses the issue by only returning items that eventually resolve to a task.