### PR TITLE
Update intriguectl

### DIFF
--- a/util/intriguectl
+++ b/util/intriguectl
@@ -68,7 +68,7 @@ if [ "$cmd" == "start" ]; then
     god -c ~/core/util/god/intrigue.rb
     god start > /dev/null
     sleep 25
-    ip=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
+    ip=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
     printf "Browse to https://$ip:7777 and login with:\nUsername: intrigue\nPassword: given or pregenerated value\n" | boxes
 elif [ "$cmd" == "stop" ]; then
     echo "[+] Stopping intrigue..."


### PR DESCRIPTION
Default ubuntu 18.04 installation already has udev rules being applied, so the default network interface will most likely not be eth0.