### PR TITLE
improvements to Binary Edge import

### DIFF
--- a/app/routes/results.rb
+++ b/app/routes/results.rb
@@ -208,8 +208,8 @@ class CoreApp < Sinatra::Base
       elsif file_format == "otx_csv"
         entities = alienvault_otx_csv_to_entities(entity_file)
       ### BinaryEdge (JSON)
-      elsif file_format == "binary_edge_json"
-        entities = binary_edge_json_to_entities(entity_file)
+      elsif file_format == "binary_edge_jsonl"
+        entities = binary_edge_jsonl_to_entities(entity_file)
       ### Shodan.io (CSV)
       elsif file_format == "shodan_csv"
         entities = shodan_csv_to_entities(filename)

--- a/app/views/_task_runner_upload.erb
+++ b/app/views/_task_runner_upload.erb
@@ -41,7 +41,7 @@
       <option value="entity_list" selected>Entity List (CSV Format: [TYPE,NAME])</option>
       <option value="intrigueio_fingerprint_csv">Collection Entity List (CSV Format [COLLECTION,TYPE,NAME])</option>
       <option value="otx_csv">Alienvault OTX (CSV)</option>
-      <option value="binary_edge_json">BinaryEdge (JSON)</option>
+      <option value="binary_edge_jsonl">BinaryEdge (JSONL)</option>
     </select>
     </div>
   </div>

--- a/lib/all.rb
+++ b/lib/all.rb
@@ -69,6 +69,11 @@ if Intrigue::Core::System::Config.config["intrigue_load_paths"]
   Intrigue::Core::System::Config.config["intrigue_load_paths"].each do |load_path|
     load_path = "#{load_path}" unless load_path[0] == "/"
 
+    Dir["#{load_path}/checks/*.rb"].each do |file|
+      #puts "Adding user handler from: #{file}"
+      require_relative file
+    end
+
     Dir["#{load_path}/entities/*.rb"].each do |file|
       #puts "Adding user entity from: #{file}"
       require_relative file
@@ -93,6 +98,11 @@ if Intrigue::Core::System::Config.config["intrigue_load_paths"]
       #puts "Adding user task from: #{file}"
       require_relative file
     end
+
+    #Dir["#{load_path}/workflows/*.rb"].each do |file|
+    #  #puts "Adding user task from: #{file}"
+    #  require_relative file
+    #end
 
   end
 end

--- a/lib/entity_manager.rb
+++ b/lib/entity_manager.rb
@@ -108,7 +108,7 @@ class EntityManager
 
     # Ensure we have an entity
     unless new_entity && new_entity.transform! && new_entity.validate_entity
-      puts "Error creating entity: #{new_entity}." + "Entity: #{type_string}##{name} #{details_hash}"
+      puts "Error creating entity: #{new_entity}. " + "Entity: #{type_string}##{name} #{details_hash}"
       return nil
     end
 

--- a/lib/system/parseable_format.rb
+++ b/lib/system/parseable_format.rb
@@ -50,15 +50,35 @@ module ParseableFormat
   entities 
   end
 
-  def binary_edge_json_to_entities(filename)
+  # Lines!
+  def binary_edge_jsonl_to_entities(filename)
     entities = []
-    json = parse_json_file filename
-    return unless json
+    lines = File.readlines(filename)
   
     # do ip_adress
-    json["target"].each do |t|
-      entities << {entity_type: "Intrigue::Entity::IpAddress", entity_name: "#{t["ip"]}", }
-      entities << {entity_type: "Intrigue::Entity::NetworkService", entity_name: "#{t["ip"]}:#{t["port"]}/#{t["protocol"]}", }
+    lines.each do |l|
+
+      json  = JSON.parse(l)
+      t = json["target"]
+      
+      #entities << {entity_type: "Intrigue::Entity::IpAddress", entity_name: "#{t["ip"]}", }
+
+      if "#{t["port"]}" =~ /80$/ || t["port"] =~ /443$/
+        scheme = "http"
+        scheme = "https" if t["port"] == ~/443$/
+
+        # ipv6 
+        if t["ip"] =~ /:/
+          ip = "[#{t["ip"]}]"
+        else 
+          ip = t["ip"]
+        end
+
+        entities << {entity_type: "Intrigue::Entity::Uri", entity_name: "#{scheme}://#{ip}:#{t["port"]}" }
+      else 
+        entities << {entity_type: "Intrigue::Entity::NetworkService", entity_name: "#{t["ip"]}:#{t["port"]}/#{t["protocol"]}" }
+      end
+      
     end
   
   entities

--- a/lib/system/validations.rb
+++ b/lib/system/validations.rb
@@ -91,9 +91,9 @@ module System
 
     def network_service_regex(anchored=true)
       if anchored
-        /^[\w\d\.\:]+:\d{1,5}$/
+        /^[\w\d\.\:]+:\d{1,5}\/tcp|udp$/
       else 
-        /\b[\w\d\.\:]+:\d{1,5}\b/
+        /\b[\w\d\.\:]+:\d{1,5}\/tcp|udp\b/
       end
     end
 


### PR DESCRIPTION
Adds / Changes Binary Edge import support to their JSONL format. Importing of network services and app endpoints (uri's) is supported. 

An improvement to this (not currently in scope) would be to bring in all the data in the export as additional details.