### PR TITLE
Add hostname entity

### DIFF
--- a/lib/entities/android_app.rb
+++ b/lib/entities/android_app.rb
@@ -18,13 +18,12 @@ class AndroidApp < Intrigue::Core::Model::Entity
 
   def scoped?
     return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
+
   true
   end
 
 end
 end
 end
-    

--- a/lib/entities/hostname.rb
+++ b/lib/entities/hostname.rb
@@ -1,0 +1,43 @@
+module Intrigue
+  module Entity
+  class Hostname < Intrigue::Core::Model::Entity
+
+    include Intrigue::Task::Dns
+
+    def self.metadata
+      {
+        name: "Hostname",
+        description: "A Hostname, unassociated with a Domain. Typically an internal, sometimes-routable, hostname",
+        user_creatable: true,
+        example: "Web-pool-001"
+      }
+    end
+
+    # gets called before entity is created
+
+    def validate_entity
+      name.match hostname_regex(true)
+    end
+
+    ###
+    ### SCOPING
+    ###
+    def scoped?(conditions={})
+      return true if scoped
+      return true if self.allow_list || self.project.allow_list_entity?(self)
+      return false if self.deny_list || self.project.deny_list_entity?(self)
+
+    # if we didnt match the above and we were asked, default to false
+    true
+    end
+
+    def scope_verification_list
+      [
+        { type_string: self.type_string, name: self.name },
+        { type_string: "Domain", name: parse_domain_name(self.name) }
+      ]
+    end
+
+  end
+  end
+  end

--- a/lib/system/validations.rb
+++ b/lib/system/validations.rb
@@ -5,19 +5,19 @@ module System
   module Validations
 
     ### Standard Validations, for use throughout the platform
-    
+
     def android_app_regex(anchored=true)
       if anchored
         /^[a-zA-Z]+[a-zA-Z0-9_\-]*\.[a-zA-Z]+[a-zA-Z0-9_\-]*\.?([a-zA-Z0-9_\-]*\.*)*$/
-      else 
+      else
         /\b[a-zA-Z]+[a-zA-Z0-9_\-]*\.[a-zA-Z]+[a-zA-Z0-9_\-]*\.?([a-zA-Z0-9_\-]*\.*)*\b/
       end
     end
 
     def asn_regex(anchored=true)
-      if anchored 
+      if anchored
         /\A(as|AS).?[0-9].*\z/i
-      else 
+      else
         /\b(as|AS).?[0-9].*\b/i
       end
     end
@@ -25,66 +25,74 @@ module System
     def credit_card_regex(anchored=true)
       if anchored
         /\A[\d+\s\-]{9,20}\z/
-      else 
+      else
         /\b[\d+\s\-]{9,20}\b/
       end
     end
 
     def dns_regex(anchored=true)
-      if anchored 
+      if anchored
         /\A[[a-z0-9]+([\_\-a-z0-9]+)*\.]+\.[a-z]{2,}\z/i
-      else 
+      else
         /\b[[a-z0-9]+([\_\-a-z0-9]+)*\.]+\.[a-z]{2,}\b/i
       end
     end
-    
+
     def email_address_regex(anchored=true)
-      if anchored 
+      if anchored
         /\A[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,8}\z/i
-      else 
+      else
         /\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,8}\b/i
       end
     end
 
+    def hostname_regex(anchored=true)
+      if anchored
+        /\A[[a-z0-9]+([\_\-a-z0-9]+)*\.]+\z/i
+      else
+        /\b[[a-z0-9]+([\_\-a-z0-9]+)*\.]+\b/i
+      end
+    end
+
     def ios_app_regex(anchored=true)
-      if anchored 
+      if anchored
         # only limit is a maximum of 30 characters, as per https://developer.apple.com/app-store/review/guidelines/
         #name.match /^.{1,30}$/ || name.match /[\w\s\-\_\.]+/
         /^[a-zA-Z]+[a-zA-Z0-9_\-]*\.[a-zA-Z]+[a-zA-Z0-9_\-]*\.?([a-zA-Z0-9_\-]*\.*)*$/
-      else 
+      else
         /\b[a-zA-Z]+[a-zA-Z0-9_\-]*\.[a-zA-Z]+[a-zA-Z0-9_\-]*\.?([a-zA-Z0-9_\-]*\.*)*\b/
       end
     end
 
     # https://tools.ietf.org/html/rfc1123
     def ipv4_regex(anchored=true)
-      if anchored 
+      if anchored
         /\A(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\z/
-      else 
+      else
         /\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b/
       end
     end
 
     def ipv6_regex(anchored=true)
-      if anchored 
+      if anchored
         /\A\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*\z/
-      else 
+      else
         /\b*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\b*/
       end
     end
 
     def netblock_regex(anchored=true)
-      if anchored 
+      if anchored
         /\A\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}\/\d{1,2}\z/i
-      else 
+      else
         /\b\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}\/\d{1,2}\b/i
       end
     end
 
     def netblock_regex_two(anchored=true)
-      if anchored 
+      if anchored
         /\A[\d\:\.]+\/\d{1,2}\z/
-      else 
+      else
         /\b[\d\:\.]+\/\d{1,2}\b/
       end
     end
@@ -92,21 +100,21 @@ module System
     def network_service_regex(anchored=true)
       if anchored
         /^[\w\d\.\:]+:\d{1,5}\/tcp|udp$/
-      else 
+      else
         /\b[\w\d\.\:]+:\d{1,5}\/tcp|udp\b/
       end
     end
 
     def phone_number_regex(anchored=true)
-      if anchored 
+      if anchored
         /\A[\s\+\d{1,2}]?\-?\.?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\z/
-      else 
+      else
         /\b[\s\+\d{1,2}]?\-?\.?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b/
       end
     end
 
     def url_regex(anchored=true)
-      if anchored 
+      if anchored
         /\Ahttps?:\/\/[\S]+\z/i
       else
         /https?:\/\/[\S]+/i


### PR DESCRIPTION
Adding a 'Hostname ' entity to represent internal or otherwise locally-routable entities. 

That this is different than a Subdomain or an IpAddress entity, in that Subdomain requires a corresponding domain ( 'host' vs 'host.domain.com') and that it is not an IpAddress, given that it must first be resolved to be usable as a routable name.