### PR TITLE
use Timeout because http2's timeout doesnt working

### DIFF
--- a/lib/tasks/uri_check_http2_status.rb
+++ b/lib/tasks/uri_check_http2_status.rb
@@ -1,3 +1,4 @@
+require 'timeout'
 module Intrigue
 module Task
 class UriCheckHttp2Support < BaseTask
@@ -54,7 +55,9 @@ class UriCheckHttp2Support < BaseTask
         end
 
         # send request
-        response = client.call(:get, '/')
+        Timeout::timeout(timeout) {
+          response = client.call(:get, '/')
+        }
 
         # close the connection
         client.close


### PR DESCRIPTION
So i've done extensive testing and can confirm the timeout of https://github.com/ostinelli/net-http2 does not work. Looking at alternative gems also didn't help, so i'm using `Timeout::timeout` to kill the operation after x seconds. Tested and working