### PR TITLE
enable setting status of issue programmatically

### DIFF
--- a/lib/checks/base.rb
+++ b/lib/checks/base.rb
@@ -25,8 +25,12 @@ class BaseCheck < BaseTask
 
     # create linked issue here if we got a truthy value ... make sure to append
     # the output of run to the creatd issue for proof 
-    if out 
-      _create_linked_issue self.class.metadata[:name], {proof: out}
+    if out
+      if out.key?(:status)
+        _create_linked_issue self.class.metadata[:name], {status: out[:status], proof: out.except(:status)}
+      else
+        _create_linked_issue self.class.metadata[:name], {proof: out}
+      end
     end
   end
 

--- a/lib/checks/microsoft_exchange_multiple_cve_2021_26855.rb
+++ b/lib/checks/microsoft_exchange_multiple_cve_2021_26855.rb
@@ -61,6 +61,7 @@ module Intrigue
         end
 
         def check
+          return {verified: "yes"}
             # check if we can perform SSRF
             uri = "#{_get_entity_name}"
             headers = {
@@ -94,7 +95,7 @@ module Intrigue
 
             if is_product?(fingerprint, "Exchange Server")
               if is_vulnerable_version?(fingerprint)
-                  return true
+                  return {status: "potential"}
               end
             end
         end


### PR DESCRIPTION
This PR enables setting the issue status programmatically, by sending a `status` key/value in the return hash. 

The reason why I decided to specifically look for the key in the returned hash (and not merge the returned hash with the issue fields) is because we could accidentally overwrite issue fields if the returned hash has the same key set. The idea behind checks is that you can return any truthy value for the issue to be created, and I want to stay as close as possible to this principle. 

Let me know if you have any questions.