### PR TITLE
Run Ruclei Template from String Bug Fix

### DIFF
--- a/lib/tasks/helpers/vuln_check.rb
+++ b/lib/tasks/helpers/vuln_check.rb
@@ -64,19 +64,19 @@ module VulnCheck
   end
 
   def run_nuclei_template_from_string(uri, template_string)
-  # run ruclei with entity name and template
-  _log "Running template against #{uri}"
-  result = false
-  begin
-    ruclei = Ruclei::Ruclei.new
-    ruclei.parse_template template_string
-    res = ruclei.run(uri)
-    return { proof: res.results } unless res.nil?
-  rescue Psych::SyntaxError # non-yaml file passed
-    _log_error 'ERROR: Specified template does not appear to be in YAML format.'
-  end
+    # run ruclei with entity name and template
+    _log "Running template against #{uri}"
+    result = false
+    begin
+      ruclei = Ruclei::Ruclei.new
+      ruclei.parse_template template_string
+      res = ruclei.run(uri)
+      return { proof: res.results } unless res.nil?
+    rescue Psych::SyntaxError # non-yaml file passed
+      _log_error 'ERROR: Specified template does not appear to be in YAML format.'
+    end
 
-result
+  return nil
   end
 
 

--- a/lib/tasks/helpers/vuln_check.rb
+++ b/lib/tasks/helpers/vuln_check.rb
@@ -71,9 +71,7 @@ module VulnCheck
     ruclei = Ruclei::Ruclei.new
     ruclei.parse_template template_string
     res = ruclei.run(uri)
-    result = res.results
-  rescue Errno::ENOENT # cannot find template
-    _log_error 'ERROR: Cannot find template at specified path.'
+    return { proof: res.results } unless res.nil?
   rescue Psych::SyntaxError # non-yaml file passed
     _log_error 'ERROR: Specified template does not appear to be in YAML format.'
   end

--- a/lib/tasks/helpers/vuln_check.rb
+++ b/lib/tasks/helpers/vuln_check.rb
@@ -60,13 +60,12 @@ module VulnCheck
       _log_error 'ERROR: Specified template does not appear to be in YAML format.'
     end
   
-  return nil
+    return nil
   end
 
   def run_nuclei_template_from_string(uri, template_string)
     # run ruclei with entity name and template
     _log "Running template against #{uri}"
-    result = false
     begin
       ruclei = Ruclei::Ruclei.new
       ruclei.parse_template template_string
@@ -76,7 +75,7 @@ module VulnCheck
       _log_error 'ERROR: Specified template does not appear to be in YAML format.'
     end
 
-  return nil
+    return nil
   end
 
 


### PR DESCRIPTION
Hi team,

Please find attached the PR to fix the issue that occurs in the `run_nuclei_template_from_string` when a nil result is returned. This performs the same logic as its counterpart function `run_nuclei_template` to correctly deal with the result.

Best regards,
Maxim
