### PR TITLE
scoped should be nil by default (not false)

### DIFF
--- a/lib/entities/android_app.rb
+++ b/lib/entities/android_app.rb
@@ -17,10 +17,9 @@ class AndroidApp < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
+    return scoped unless scoped.nil?
     return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-
   true
   end
 

--- a/lib/entities/api_endpoint.rb
+++ b/lib/entities/api_endpoint.rb
@@ -1,7 +1,7 @@
 module Intrigue
 module Entity
 class ApiEndpoint < Intrigue::Core::Model::Entity
-  
+
   def self.metadata
     {
       name: "ApiEndpoint",
@@ -16,10 +16,10 @@ class ApiEndpoint < Intrigue::Core::Model::Entity
   end
 
   def detail_string
-    
+
     # create fingerprint
     if details["fingerprint"]
-      fingerprint_array = details["fingerprint"].map do |x| 
+      fingerprint_array = details["fingerprint"].map do |x|
         "#{x['vendor']} #{x['product'] unless x['vendor'] == x['product']} #{x['version']}".strip
       end
       out = "Fingerprint: #{fingerprint_array.sort.uniq.join("; ")}" if details["fingerprint"]
@@ -29,7 +29,7 @@ class ApiEndpoint < Intrigue::Core::Model::Entity
 
     if details["title"]
       out << " | " if out.length > 0
-      out << " Title: #{details["title"]}" 
+      out << " Title: #{details["title"]}"
     end
 
   out
@@ -38,9 +38,9 @@ class ApiEndpoint < Intrigue::Core::Model::Entity
   ###
   ### SCOPING
   ###
-  def scoped?(conditions={}) 
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+  def scoped?(conditions={})
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
   # if we didnt match the above and we were asked, it's still true

--- a/lib/entities/autonomous_system.rb
+++ b/lib/entities/autonomous_system.rb
@@ -16,12 +16,12 @@ class AutonomousSystem < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
   false # otherwise false
   end
-  
+
 end
 end
 end

--- a/lib/entities/aws_credential.rb
+++ b/lib/entities/aws_credential.rb
@@ -34,8 +34,8 @@ class AwsCredential < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
   true # otherwise just default to true
   end

--- a/lib/entities/aws_iam_account.rb
+++ b/lib/entities/aws_iam_account.rb
@@ -16,12 +16,12 @@ class AwsIamAccount < Intrigue::Core::Model::Entity
   end
 
   def detail_string
-    "Organization: #{details["organization"]} / Type: #{details["account_type"]} / Name: #{name}" 
+    "Organization: #{details["organization"]} / Type: #{details["account_type"]} / Name: #{name}"
   end
- 
+
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
   true # otherwise just default to true
   end

--- a/lib/entities/aws_region.rb
+++ b/lib/entities/aws_region.rb
@@ -6,7 +6,7 @@ class AwsRegion < Intrigue::Core::Model::Entity
     {
       name: "AwsRegion",
       description:"A specific AWS Region",
-      user_creatable: true, 
+      user_creatable: true,
       example: "us-east-1"
     }
   end
@@ -41,8 +41,8 @@ class AwsRegion < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
   true # otherwise just default to true
   end

--- a/lib/entities/aws_s3_bucket.rb
+++ b/lib/entities/aws_s3_bucket.rb
@@ -24,8 +24,8 @@ class AwsS3Bucket < Intrigue::Core::Model::Entity
   end
 
   def scoped?(conditions={})
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
   true # otherwise just default to true

--- a/lib/entities/credential.rb
+++ b/lib/entities/credential.rb
@@ -14,18 +14,18 @@ class Credential < Intrigue::Core::Model::Entity
   def validate_entity
     out1 = name.match(/^[\w\s\d\.\-\_\&\;\:\,\@]+$/)
 
-    if details 
+    if details
       out2 = details["username"].to_s.match(/^\w.*$/) &&
       details["password"].to_s.match(/^\w.*$/) &&
       details["uri"].to_s.match(/^http:.*$/)
     end
 
-  out1 && out2 
+  out1 && out2
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
   true # otherwise just default to true
   end

--- a/lib/entities/credit_card.rb
+++ b/lib/entities/credit_card.rb
@@ -1,32 +1,31 @@
 module Intrigue
   module Entity
   class CreditCard < Intrigue::Core::Model::Entity
-  
+
     def self.metadata
       {
         name: "CreditCard",
         description: "A Credit Card",
-        user_creatable: false, 
+        user_creatable: false,
         example: "4111111111111111"
       }
     end
-  
+
     def validate_entity
       name =~ credit_card_regex(true)
     end
-  
+
     def detail_string
-      "*************#{name[-4..-1]}" 
+      "*************#{name[-4..-1]}"
     end
-   
+
     def scoped?
-      return true if scoped
-      return true if self.allow_list || self.project.allow_list_entity?(self) 
+      return scoped unless scoped.nil?
+      return true if self.allow_list || self.project.allow_list_entity?(self)
       return false if self.deny_list || self.project.deny_list_entity?(self)
     true # otherwise just default to true
     end
-  
+
   end
   end
   end
-  

--- a/lib/entities/dns_record.rb
+++ b/lib/entities/dns_record.rb
@@ -1,7 +1,7 @@
 module Intrigue
 module Entity
 class DnsRecord < Intrigue::Core::Model::Entity
-  
+
   include Intrigue::Task::Dns
 
   def self.metadata
@@ -37,9 +37,9 @@ class DnsRecord < Intrigue::Core::Model::Entity
   ###
   ### SCOPING
   ###
-  def scoped?(conditions={}) 
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+  def scoped?(conditions={})
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
   # if we didnt match the above and we were asked, default to false

--- a/lib/entities/domain.rb
+++ b/lib/entities/domain.rb
@@ -17,14 +17,14 @@ class Domain < Intrigue::Core::Model::Entity
     name = SimpleIDN.to_ascii(name)
     return name, details_hash
   end
-  
+
   def validate_entity
     name.match dns_regex(true)
   end
 
   def detail_string
     return "" unless details["resolutions"]
-    details["resolutions"].each.group_by{|k| 
+    details["resolutions"].each.group_by{|k|
       k["response_type"] }.map{|k,v| "#{k}: #{v.length}"}.join(" | ")
   end
 
@@ -35,12 +35,12 @@ class Domain < Intrigue::Core::Model::Entity
   ###
   ### SCOPING
   ###
-  def scoped?(conditions={}) 
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+  def scoped?(conditions={})
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
-  # if we didnt match the above and we were asked, let's not allow it 
+  # if we didnt match the above and we were asked, let's not allow it
   false
   end
 

--- a/lib/entities/email_address.rb
+++ b/lib/entities/email_address.rb
@@ -16,15 +16,15 @@ class EmailAddress < Intrigue::Core::Model::Entity
   end
 
   def detail_string
-    "#{details["origin"]}" if details 
+    "#{details["origin"]}" if details
   end
 
   ###
   ### SCOPING
   ###
-  def scoped?(conditions={}) 
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+  def scoped?(conditions={})
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
   false

--- a/lib/entities/file_hash.rb
+++ b/lib/entities/file_hash.rb
@@ -26,10 +26,10 @@ class FileHash < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
+
   true
   end
 

--- a/lib/entities/github_account.rb
+++ b/lib/entities/github_account.rb
@@ -20,10 +20,10 @@ class GithubAccount < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
+
   true
   end
 

--- a/lib/entities/github_repository.rb
+++ b/lib/entities/github_repository.rb
@@ -16,8 +16,8 @@ class GithubRepository < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
   true

--- a/lib/entities/hostname.rb
+++ b/lib/entities/hostname.rb
@@ -23,7 +23,7 @@ module Intrigue
     ### SCOPING
     ###
     def scoped?(conditions={})
-      return true if scoped
+      return scoped unless scoped.nil?
       return true if self.allow_list || self.project.allow_list_entity?(self)
       return false if self.deny_list || self.project.deny_list_entity?(self)
 

--- a/lib/entities/ios_app.rb
+++ b/lib/entities/ios_app.rb
@@ -16,10 +16,10 @@ class IosApp < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
+
   true
   end
 

--- a/lib/entities/ip_address.rb
+++ b/lib/entities/ip_address.rb
@@ -19,7 +19,7 @@ class IpAddress < Intrigue::Core::Model::Entity
     out = ""
 
     if details["geolocation"] && details["geolocation"]["country_code"]
-      out << "#{details["geolocation"]["city"]} #{details["geolocation"]["country_code"]} | " 
+      out << "#{details["geolocation"]["city"]} #{details["geolocation"]["country_code"]} | "
     end
 
     if details["ports"] && details["ports"].count > 0
@@ -29,7 +29,7 @@ class IpAddress < Intrigue::Core::Model::Entity
     if details["resolutions"]
       out << " PTR: #{details["resolutions"].each.map{|h| h["response_data"] }.join(" | ")}"
     end
-    
+
   out
   end
 
@@ -40,18 +40,18 @@ class IpAddress < Intrigue::Core::Model::Entity
   ###
   ### SCOPING
   ###
-  def scoped?(conditions={}) 
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+  def scoped?(conditions={})
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
-    # while it might be nice to scope out stuff on third paries, we still need 
+    # while it might be nice to scope out stuff on third paries, we still need
     # to keep it in to scan, so we'll need to check scope at that level
 
   # if we didnt match the above and we were asked, default to true as we'll
   #  we'll want to scope things in before we have a full set of aliases
   true
-  end 
+  end
 
 end
 end

--- a/lib/entities/mailserver.rb
+++ b/lib/entities/mailserver.rb
@@ -14,7 +14,7 @@ class Mailserver < Intrigue::Core::Model::Entity
   end
 
   def validate_entity
-    return name.match(ipv4_regex) || name.match(ipv6_regex) || name.match(dns_regex) 
+    return name.match(ipv4_regex) || name.match(ipv6_regex) || name.match(dns_regex)
   end
 
   def enrichment_tasks
@@ -24,12 +24,12 @@ class Mailserver < Intrigue::Core::Model::Entity
     ###
   ### SCOPING
   ###
-  def scoped?(conditions={}) 
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+  def scoped?(conditions={})
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
-  # if we didnt match the above and we were asked, it's false 
+  # if we didnt match the above and we were asked, it's false
   false
   end
 
@@ -40,7 +40,7 @@ class Mailserver < Intrigue::Core::Model::Entity
       { type_string: "Domain", name:  parse_domain_name(self.name) }
     ]
   end
-  
+
 end
 end
 end

--- a/lib/entities/nameserver.rb
+++ b/lib/entities/nameserver.rb
@@ -14,7 +14,7 @@ class Nameserver < Intrigue::Core::Model::Entity
   end
 
   def validate_entity
-    return name.match(ipv4_regex) || name.match(ipv6_regex) || name.match(dns_regex) 
+    return name.match(ipv4_regex) || name.match(ipv6_regex) || name.match(dns_regex)
   end
 
   def enrichment_tasks
@@ -24,12 +24,12 @@ class Nameserver < Intrigue::Core::Model::Entity
   ###
   ### SCOPING
   ###
-  def scoped?(conditions={}) 
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+  def scoped?(conditions={})
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
-  # if we didnt match the above and we were asked, it's false 
+  # if we didnt match the above and we were asked, it's false
   false
   end
 

--- a/lib/entities/net_block.rb
+++ b/lib/entities/net_block.rb
@@ -26,9 +26,9 @@ class NetBlock < Intrigue::Core::Model::Entity
   ###
   ### SCOPING
   ###
-  def scoped?(conditions={}) 
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+  def scoped?(conditions={})
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
     our_ip = self.name.split("/").first
@@ -43,15 +43,15 @@ class NetBlock < Intrigue::Core::Model::Entity
     #end
 
     ###
-    ### First, check our text to see if there's a more specific route in here, 
+    ### First, check our text to see if there's a more specific route in here,
     ###  and if so, not ours.
     #########################################################################
     match_captures = whois_text.scan(netblock_regex)
     match_captures.each do |capture|
-      
+
       ip = capture.first.split("/").first
       route = capture.last
-      
+
       # compare each to our lookup stringg
       if ip == our_ip && route > our_route
         return false
@@ -59,13 +59,13 @@ class NetBlock < Intrigue::Core::Model::Entity
 
     end
 
-    # Check types we'll check for indicators 
+    # Check types we'll check for indicators
     # of in-scope-ness
     #
     scope_check_entity_types = [
       "Intrigue::Entity::Organization",
       "Intrigue::Entity::DnsRecord",
-      "Intrigue::Entity::Domain" 
+      "Intrigue::Entity::Domain"
     ]
 
     ### Now check our seed entities for a match
@@ -76,9 +76,9 @@ class NetBlock < Intrigue::Core::Model::Entity
 
         next unless scope_check_entity_types.include? "#{xtype}"
         if whois_text.match /@#{Regexp.escape(xname)}/i
-          
+
           # Log our scope change
-          log_string = " - [#{self.project.name}] Entity #{xtype} #{xname} set scoped on #{self.name} " + 
+          log_string = " - [#{self.project.name}] Entity #{xtype} #{xname} set scoped on #{self.name} " +
                         "to true, reason: whois text matched #{xname}"
 
           Intrigue::Core::Model::ScopingLog.log log_string
@@ -88,14 +88,14 @@ class NetBlock < Intrigue::Core::Model::Entity
       end
     end
 
-    ### And now, let's check our corpus of already-scoped stuff from this run 
+    ### And now, let's check our corpus of already-scoped stuff from this run
     #############################################################################
     #self.project.entities.where(scoped: true, type: scope_check_entity_types ).each do |e|
     #  # make sure we skip any dns entries that are not fqdns. this will prevent
     #  # auto-scoping on a single name like "log" or even a number like "1"
     #  next if (e.type == "DnsRecord" || e.type == "Domain") && e.name.split(".").count == 1
-    #  # Now, check to see if the entity's name matches something in our # whois text, 
-    #  # and especially make sure 
+    #  # Now, check to see if the entity's name matches something in our # whois text,
+    #  # and especially make sure
     #  if whois_text.match /@#{Regexp.escape(e.name)}/i
     #
     #    # Log our scope change
@@ -108,16 +108,16 @@ class NetBlock < Intrigue::Core::Model::Entity
 
     # now check more edge cases
 
-    ### CHECK OUR IN-PROJECT ENTITIES TO SEE IF THE ORG NAME MATCHES 
+    ### CHECK OUR IN-PROJECT ENTITIES TO SEE IF THE ORG NAME MATCHES
     #######################################################################
     #if details["organization"] || details["organization_name"]
     #  self.project.entities.where(scoped: true, type: scope_check_entity_types ).each do |e|
     #    # make sure we skip any dns entries that are not fqdns. this will prevent
     #    # auto-scoping on a single name like "log" or "www" or even a number like "1"
     #    next if (e.type == "DnsRecord" || e.type == "Domain") && e.name.split(".").count == 1
-    #    # Now, check to see if the entity's name matches something in our # whois text, 
-    #    # and especially make sure 
-    #    if (details["organization"].match /@#{Regexp.escape(e.name)}/i) || 
+    #    # Now, check to see if the entity's name matches something in our # whois text,
+    #    # and especially make sure
+    #    if (details["organization"].match /@#{Regexp.escape(e.name)}/i) ||
     #        (details["organization_name"].match /@#{Regexp.escape(e.name)}/i)
     #
     #        # Log our scope change
@@ -133,12 +133,12 @@ class NetBlock < Intrigue::Core::Model::Entity
     #    # Log our scope change
     #    log_string = " - [#{e.project.name}] Entity #{e.type} #{e.name} set scoped on #{self.name} to true, reason: missing whois text and small cidr"
     #    Intrigue::Core::Model::ScopingLog.log log_string
-    #    
-    #    return true 
+    #
+    #    return true
     #  end
     #end
 
-  # if we didnt match the above and we were asked, it's false 
+  # if we didnt match the above and we were asked, it's false
   false
   end
 

--- a/lib/entities/network_service.rb
+++ b/lib/entities/network_service.rb
@@ -21,7 +21,7 @@ class NetworkService < Intrigue::Core::Model::Entity
 
     # create fingerprint details string
     out = "#{short_fingerprint_string(details["fingerprint"])} | " if details["fingerprint"]
-      
+
     out << "Port: #{details["service"]}"
   end
 
@@ -30,11 +30,11 @@ class NetworkService < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
-    # only scope in stuff that's not hidden 
+
+    # only scope in stuff that's not hidden
     return false if self.hidden
 
   true

--- a/lib/entities/organization.rb
+++ b/lib/entities/organization.rb
@@ -20,10 +20,10 @@ class Organization < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
+
   false
   end
 

--- a/lib/entities/person.rb
+++ b/lib/entities/person.rb
@@ -20,10 +20,10 @@ class Person < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
+
   true
   end
 

--- a/lib/entities/phone_number.rb
+++ b/lib/entities/phone_number.rb
@@ -18,12 +18,12 @@ class PhoneNumber < Intrigue::Core::Model::Entity
   def detail_string
     "#{details["origin"]}"
   end
-  
+
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
- 
+
   true
   end
 

--- a/lib/entities/physical_location.rb
+++ b/lib/entities/physical_location.rb
@@ -17,10 +17,10 @@ class PhysicalLocation < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
+
   false
   end
 

--- a/lib/entities/software_package.rb
+++ b/lib/entities/software_package.rb
@@ -20,13 +20,13 @@ class SoftwarePackage < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
+
   true
   end
-  
+
 end
 end
 end

--- a/lib/entities/ssl_certificate.rb
+++ b/lib/entities/ssl_certificate.rb
@@ -31,11 +31,11 @@ class SslCertificate < Intrigue::Core::Model::Entity
   ###
   ### SCOPING
   ###
-  def scoped?(conditions={}) 
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+  def scoped?(conditions={})
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
+
   true
   end
 

--- a/lib/entities/string.rb
+++ b/lib/entities/string.rb
@@ -20,10 +20,10 @@ class String < Intrigue::Core::Model::Entity
   end
 
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
-  
+
   true
   end
 

--- a/lib/entities/unique_keyword.rb
+++ b/lib/entities/unique_keyword.rb
@@ -1,7 +1,7 @@
 module Intrigue
   module Entity
   class UniqueKeyword < Intrigue::Core::Model::Entity
-  
+
     def self.metadata
       {
         name: "UniqueKeyword",
@@ -10,19 +10,19 @@ module Intrigue
         example: "Intrigue.io"
       }
     end
-  
+
     def validate_entity
       name.match /^([\,\w\d\ \-\(\)\\\/]+)$/
     end
 
     def scoped?
-      return true if scoped
+      return scoped unless scoped.nil?
       return true if self.allow_list
       return false if self.deny_list
-    
+
     true
     end
-  
+
 end
 end
 end

--- a/lib/entities/uri.rb
+++ b/lib/entities/uri.rb
@@ -16,10 +16,10 @@ class Uri < Intrigue::Core::Model::Entity
   end
 
   def detail_string
-    
+
     # create fingerprint
     if details["fingerprint"]
-      fingerprint_array = details["fingerprint"].map do |x| 
+      fingerprint_array = details["fingerprint"].map do |x|
         "#{x['vendor']} #{x['product'] unless x['vendor'] == x['product']} #{x['version']}".strip
       end
       out = "Fingerprint: #{fingerprint_array.sort.uniq.join("; ")}" if details["fingerprint"]
@@ -39,12 +39,12 @@ class Uri < Intrigue::Core::Model::Entity
   ###
   ### SCOPING
   ###
-  def scoped?(conditions={}) 
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+  def scoped?(conditions={})
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
 
-    # only scope in stuff that's not hidden 
+    # only scope in stuff that's not hidden
     return false if self.hidden
 
   # if we didnt match the above and we were asked, it's still true

--- a/lib/entities/web_account.rb
+++ b/lib/entities/web_account.rb
@@ -11,15 +11,15 @@ class WebAccount < Intrigue::Core::Model::Entity
   end
 
   def validate_entity
-    name.match /^[\w\d\.\-\(\)\\\/\_]+:\s?[\w\d\.\-\(\)\\\/\_]+$/ 
+    name.match /^[\w\d\.\-\(\)\\\/\_]+:\s?[\w\d\.\-\(\)\\\/\_]+$/
   end
 
   def transform!
-    
+
     username = details["hidden_original"].split(":").last.strip
     service_name = details["hidden_original"].split(":").first.strip
 
-    # force a space 
+    # force a space
     self.name = "#{service_name}: #{username}"
     save_changes
 
@@ -34,10 +34,10 @@ class WebAccount < Intrigue::Core::Model::Entity
   true
   end
 
-  
+
   def scoped?
-    return true if scoped
-    return true if self.allow_list || self.project.allow_list_entity?(self) 
+    return scoped unless scoped.nil?
+    return true if self.allow_list || self.project.allow_list_entity?(self)
     return false if self.deny_list || self.project.deny_list_entity?(self)
   true
   end

--- a/lib/entity_manager.rb
+++ b/lib/entity_manager.rb
@@ -284,8 +284,8 @@ class EntityManager
 
       unless entity.seed?
         tr.log "Entity was specifically requested to be unscoped"
-        entity.delete_detail("unscoped")
         scope_request = "false"
+        entity.delete_detail("unscoped")
       else
         tr.log "Entity was specifically requested to be unscoped, but it's a seed, so we refused!"
       end


### PR DESCRIPTION
pr changes default value for scoped attribute on entity/issue. cleans up a fun condition for 'unscoped' entities where they were being scoped by the enrichment process due to how the 'unscoped' setting was being deleted/not checked. Should result in dns_recurse_spf no longer creating ip address entities that get scoped in automatically. 