### PR TITLE
use http-2 gem for http2 target testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,9 +96,11 @@ gem 'ip_ranger',              :git => "https://github.com/intrigueio/ip_ranger"
 gem 'ipaddr'
 gem 'maxminddb',              :git => "https://github.com/intrigueio/maxminddb"
 gem 'net-dns'                 # dns_cache_snoop
-gem 'net-http2'               # http2 client support
+gem 'net-http2'               
+gem 'http-2'               # http2 client support
 gem 'neutrino_api',           :git => 'https://github.com/intrigueio/NeutrinoAPI-Ruby.git'
 gem 'opencorporates',         :git => 'https://github.com/pentestify/opencorporates.git'
+gem 'openssl'
 gem 'rex'
 gem 'rex-sslscan',            :git => 'https://github.com/intrigueio/rex-sslscan.git'
 gem 'ruby-nmap',              :git => 'https://github.com/pentestify/ruby-nmap.git'

--- a/lib/tasks/uri_check_http2_status.rb
+++ b/lib/tasks/uri_check_http2_status.rb
@@ -1,4 +1,3 @@
-require 'timeout'
 module Intrigue
 module Task
 class UriCheckHttp2Support < BaseTask
@@ -39,67 +38,132 @@ class UriCheckHttp2Support < BaseTask
 
   end #end run
 
-  def check_h2_sync(uri)
+  def check_h2_sync(uri_param)
 
+    # require enrichment
     require_enrichment
+    draft = 'h2'
 
-    if _get_entity_detail("code") == "0"
-      _log_error "unable to proceed, connection reset"
-      return
-    end
+    # return data
+    res_code = nil
+    res_headers = nil
 
-    begin
+    uri = URI.parse(uri_param)
+    tcp = TCPSocket.new(uri.host, uri.port)
+    sock = nil
 
-      # create a client
-      timeout = "#{_get_option("connect_timeout")}".to_i
+    if uri.scheme == 'https'
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
-      client = ::NetHttp2::Client.new(uri, connect_timeout: timeout)
+      # For ALPN support, Ruby >= 2.3 and OpenSSL >= 1.0.2 are required
 
-      error = false
-      # error handling
-      client.on :error do |e|
-        _log_error "Client encountered an error:"
-        _log_error e
-        error = true
+      ctx.alpn_protocols = [draft]
+      ctx.alpn_select_cb = lambda do |protocols|
+        # puts "ALPN protocols supported by server: #{protocols}"
+        draft if protocols.include? draft
       end
 
-      # send request
-      response = client.call(:get, _get_entity_name)
-      return unless response
-      return if error
+      sock = OpenSSL::SSL::SSLSocket.new(tcp, ctx)
+      sock.sync_close = true
+      sock.hostname = uri.hostname
+      sock.connect
 
-      # read the response
-      response.ok?      # => true
-      response.status   # => '200'
-      response.headers  # => {":status"=>"200"}
-      response.body     # => "A body"
+      if sock.alpn_protocol != draft
+        # puts "Failed to negotiate #{draft} via ALPN"
+        return [nil, nil, nil]
+      end
+    else
+      sock = tcp
+    end
 
+    conn = HTTP2::Client.new
+    stream = conn.new_stream
 
-      # close the connection
-      client.close
+    conn.on(:frame) do |bytes|
+      # puts "Sending bytes: #{bytes.unpack("H*").first}"
+      sock.print bytes
+      sock.flush
+    end
+    conn.on(:frame_sent) do |frame|
+      # puts "Sent frame: #{frame.inspect}"
+    end
+    conn.on(:frame_received) do |frame|
+      # puts "Received frame: #{frame.inspect}"
+    end
 
-    rescue TypeError => e  # IS there a better way to do this?
-      _log_error "Unable to connect"
-    rescue OpenSSL::SSL::SSLError => e
-      _log_error "Unable to connect, ssl error"
-    rescue Errno::EPIPE => e
-      _log_error "Unable to connect, broken pipe"
-    rescue Errno::EHOSTUNREACH => e
-      _log_error "Unable to connect, host unreachable"
-    rescue Errno::ECONNREFUSED => e
-      _log_error "Unable to connect, connection refused"
-    rescue Errno::ECONNRESET => e
-      _log_error "Unable to connect, connection reset"
-    rescue Errno::ETIMEDOUT => e
-      _log_error "Unable to connect, timed out"
-    rescue SocketError => e
-      _log_error "Unable to connect, socket error"
+    conn.on(:promise) do |promise|
+      promise.on(:promise_headers) do |h|
+        # _log "promise request headers: #{h}"
+      end
+
+      promise.on(:headers) do |h|
+        # _log "promise headers: #{h}"
+      end
+
+      promise.on(:data) do |d|
+        # _log "promise data chunk: <<#{d.size}>>"
+      end
+    end
+
+    conn.on(:altsvc) do |f|
+      # _log "received ALTSVC #{f}"
+    end
+
+    stream.on(:close) do
+      # _log 'stream closed'
+    end
+
+    stream.on(:half_close) do
+      # _log 'closing client-end of the stream'
+    end
+
+    stream.on(:headers) do |h|
+      # _log "response headers: #{h}"
+      res_headers = h
+      h.each do |hh|
+        if hh[0] == ":status"
+          res_code = hh[1]
+          _log "Received response code: #{code}"
+        end
+      end
+    end
+
+    stream.on(:data) do |d|
+      # _log "response data chunk: <<#{d}>>"
+    end
+
+    stream.on(:altsvc) do |f|
+      # _log "received ALTSVC #{f}"
+    end
+
+    head = {
+      ':scheme' => uri.scheme,
+      ':method' => 'GET',
+      ':authority' => [uri.host, uri.port].join(':'),
+      ':path' => uri.path,
+      'accept' => '*/*'
+    }
+
+    _log 'Sending HTTP 2.0 GET request'
+    stream.headers(head, end_stream: true)
+    while !sock.closed? && !sock.eof?
+      data = sock.read_nonblock(1024)
+      # puts "Received bytes: #{data.unpack("H*").first}"
+
+      begin
+        conn << data
+      rescue StandardError => e
+        # puts "#{e.class} exception: #{e.message} - closing socket."
+        e.backtrace.each { |l| puts "\t" + l }
+        sock.close
+      end
     end
 
     # just fail
-    return [nil,nil,nil] unless response
+    #return [nil,nil,nil] unless response
 
-  [response.ok?, response, response.headers]
+  return [true, res_code, res_headers]
   end
 
 end


### PR DESCRIPTION
This is an alternative approach to testing http2, taken from https://github.com/igrigorik/http-2 . Tested and appears to be working correctly ( I used [https://tools.keycdn.com/http2-test](https://tools.keycdn.com/http2-test) to confirm results with the tasks).

@jcran would love your review here, especially around Gemfile and Gemfile.lock since this added a new gem.