### PR TITLE
Route53 Gather Records Task

### DIFF
--- a/lib/tasks/aws_route53.rb
+++ b/lib/tasks/aws_route53.rb
@@ -84,7 +84,7 @@ class AwsRoute53 < BaseTask
         when 'NS'
           # only save the values
           nameservers = item.resource_records.map(&:value)
-          _log_good "Retrieved #{nameservers.size} NS records."
+          _log_good "Retrieved #{nameservers.size} NS records associated with #{item.name}"
           nameservers.compact.uniq.each { |n| _create_entity 'Nameserver', 'name' => n.scan(subdomain_regex).last.first }
         when 'MX'
           # only save the values -> may save the record name as well however most of the time its set for the domain rather than a specific subdomain

--- a/lib/tasks/aws_route53.rb
+++ b/lib/tasks/aws_route53.rb
@@ -5,9 +5,9 @@ class AwsRoute53 < BaseTask
   def self.metadata
     {
       :name => 'aws_route53',
-      :pretty_name => 'AWS Route53 Zone Pull',
+      :pretty_name => 'AWS Route53 Gather Records',
       :authors => ['Anas Ben Salah', 'maxim'],
-      :description => 'This task hits the Route53 API for enumerating Dns Records for a specific domain. Please ensure the following policy perimssions are set:<br /> - maxim<br /> - maxim<br> <b>Please note that if no Hosted Zone ID is provided; this task will retrieve records for all accessible Hosted Zones.</b>',
+      :description => 'This task hits the Route53 API for enumerating DNS Records. Please ensure the <i>ListResourceRecordSets</i> permission is set in the policy for which the keys are associated with in order to retrieve records from a Hosted Zone. <br/><br/><b>Please note that if no Hosted Zone ID is provided; this task will retrieve records for all accessible Hosted Zones.</b>',
       :references => ['https://docs.aws.amazon.com/Route53/latest/APIReference/Welcome.html'],
       :type => 'discovery',
       :passive => true,

--- a/lib/tasks/aws_route53.rb
+++ b/lib/tasks/aws_route53.rb
@@ -1,19 +1,21 @@
 module Intrigue
 module Task
-class AWSroute53 < BaseTask
+class AwsRoute53 < BaseTask
 
   def self.metadata
     {
-      :name => "aws_route53",
-      :pretty_name => "AWS Route53 Zone Pull",
-      :authors => ["Anas Ben Salah"],
-      :description => "This task hits the Route53 API for enumerating Dns Records for a specific domain",
-      :references => ["https://docs.aws.amazon.com/Route53/latest/APIReference/Welcome.html"],
-      :type => "discovery",
+      :name => 'aws_route53',
+      :pretty_name => 'AWS Route53 Zone Pull',
+      :authors => ['Anas Ben Salah', 'maxim'],
+      :description => 'This task hits the Route53 API for enumerating Dns Records for a specific domain. Please ensure the following policy perimssions are set:<br /> - maxim<br /> - maxim<br> Please note that if no Hosted Zone ID is provided; this task will retrieve records for all accessible Hosted Zones.',
+      :references => ['https://docs.aws.amazon.com/Route53/latest/APIReference/Welcome.html'],
+      :type => 'discovery',
       :passive => true,
-      :allowed_types => ["Domain"],
-      :example_entities => [{"type" => "Domain", "details" => {"name" => "letshopeit.works"}}],
-      :allowed_options => [],
+      :allowed_types => ['String'],
+      :example_entities => [{ 'type' => 'String', 'details' => { 'name' => 'Hosted Zone ID (Optional)' } }],
+      :allowed_options => [
+       # { :name => 'Hosted Zone ID (Optional)', :regex => "alpha_numeric", :default => '' }
+      ],
       :created_types => []
     }
   end
@@ -22,49 +24,80 @@ class AWSroute53 < BaseTask
   def run
     super
 
-    # Get the entity name to investigate
-    entity_name= _get_entity_name
-
-    # set zoneid
-    zoneid = "unknown"
-
-    # Get the AWS Route53 Credentials
-    r53 = Aws::Route53::Client.new({
-      region: _get_task_config("aws_region"),
-      access_key_id: _get_task_config("aws_access_key_id"),
-      secret_access_key: _get_task_config("aws_secret_access_key")
-    })
-
-    # Get the zones
-    resp = r53.list_hosted_zones
-
-    resp[:hosted_zones].each do |zone|
-
-      #check if the zone name matches the domain to investigate
-      if zone[:name].include? entity_name
-
-        zoneid = zone[:id]
-        # info on zone
-        zoneinfo = r53.get_hosted_zone({:id => zoneid})
-        #records = r53.list_resource_record_sets({:hosted_zone_id => zoneid})
-        # create nameservers for each zone
-        zoneinfo["delegation_set"]["name_servers"].each do |e|
-
-          _create_entity("Nameserver", {"name" => (e).to_s})
-        end
-
-        #all records for zone
-        #records = r53.list_resource_record_sets({:hosted_zone_id => zoneid})
-        #puts records
-
-      end
+    r53 = Aws::Route53::Client.new(
+      {
+        region: _get_task_config('aws_region'),
+        access_key_id: _get_task_config('aws_access_key_id'),
+        secret_access_key: _get_task_config('aws_secret_access_key')
+      }
+    )
+    begin
+      # get an invalid hosted zone id to check if keys are valid
+      r53.get_hosted_zone({ id: 'INVALIDZONE' })
+    rescue Aws::Route53::Errors::InvalidClientTokenId
+      _log_error 'Invalid Access Key ID.'
+      return nil
+    rescue Aws::Route53::Errors::SignatureDoesNotMatch
+      _log_error 'Secret Access Key does not match Access Key ID.'
+      return nil
+    rescue Aws::Route53::Errors::NoSuchHostedZone
+      # pass we expect this to happen if keys are correct
     end
 
+    zone_ids = []
+    record_sets = []
 
+    if _get_entity_name =~ /^Z[a-z0-9]*$/i # hosted zone always begins with a Z (there is no set amount of chars)
+      zone_ids << _get_entity_name
+    else
+      zone_ids = retrieve_all_hosted_zone_ids r53
+    end
 
-  end #end run
+    zone_ids.each do |zid|
+      record_sets << r53.list_resource_record_sets({ :hosted_zone_id => zid })
+    rescue Aws::Route53::Errors::AccessDenied
+      _log_error "API Key lacks permission to retrieve records from Zone: #{zid}."
+    rescue Aws::Route53::Errors::NoSuchHostedZone
+      _log_error "Invalid Host Zone ID: #{zid}."
+    end
 
+    record_sets.each { |set| retrieve_record_names(set) } # maybe unless set.nil?
+  end # end run
 
-end #end class
+  # NO HOSTED ZONE PROVIDED - CALL THIS
+  def retrieve_all_hosted_zone_ids(r53)
+    begin
+      response = r53.list_hosted_zones
+    rescue Aws::Route53::Errors::AccessDenied
+      _log_error 'API Key lacks permission to List Hosted Zones. Ensure the ListHostedZones permission is set or provide a Hosted Zone ID.'
+      return nil
+    end
+    # what if there are no hosted zones? need to create new aws account to test this out
+    response.hosted_zones.map { |hz| hz.id.split('/')[2] if hz }
+  end
+
+  def retrieve_record_names(records)
+    subdomain_regex = /([a-zA-Z0-9][a-zA-Z0-9.-]+[a-zA-Z0-9])/
+    records.each do |record|
+      record.resource_record_sets.each do |item|
+        case item.type
+        when 'NS'
+          # only save the values
+          nameservers = item.resource_records.map(&:value)
+          _log_good "Retrieved #{nameservers.size} NS records."
+          nameservers.compact.uniq.each { |n| _create_entity 'Nameserver', 'name' => n.scan(subdomain_regex).last.first }
+        when 'MX'
+          # only save the values -> may save the record name as well however most of the time its set for the domain rather than a specific subdomain
+          mxvalues = item.resource_records.map(&:value)
+          mxvalues.compact.uniq.each { |m| _create_entity 'Mailserver', 'name' => m.scan(subdomain_regex).last.first }
+        when 'A', 'CNAME', 'AAAA', 'SRV'
+          _log_good "Retrieved the following #{item.type} Record: #{item.name.scan(subdomain_regex).last.first}"
+          _create_entity 'DnsRecord', 'name' => item.name.scan(subdomain_regex).last.first
+        end
+      end
+    end
+  end
+
+end
 end
 end

--- a/lib/tasks/enrich/mailserver.rb
+++ b/lib/tasks/enrich/mailserver.rb
@@ -22,12 +22,11 @@ module Intrigue
     def run
       super
       _log "Enriching... Nameserver: #{_get_entity_name}"
-  
 
       # Use intrigue-ident code to request the banner and fingerprint
       _log "Grabbing banner and fingerprinting!"
       ident_matches = generate_smtp_request_and_check(_get_entity_name) || {}
-      ident_fingerprints = ident_matches["fingerprints"]
+      ident_fingerprints = ident_matches["fingerprints"] || []
       _log "Got #{ident_fingerprints.count} fingerprints!"
 
       # get the request/response we made so we can keep track of redirects

--- a/lib/tasks/enrich/mailserver.rb
+++ b/lib/tasks/enrich/mailserver.rb
@@ -25,7 +25,9 @@ module Intrigue
 
       # Use intrigue-ident code to request the banner and fingerprint
       _log "Grabbing banner and fingerprinting!"
-      ident_matches = generate_smtp_request_and_check(_get_entity_name) || {}
+      
+      ident = Intrigue::Ident::Ident.new
+      ident_matches = ident.generate_smtp_request_and_check(_get_entity_name) || {}
       ident_fingerprints = ident_matches["fingerprints"] || []
       _log "Got #{ident_fingerprints.count} fingerprints!"
 


### PR DESCRIPTION
Hi team,

Please find in this PR the task which is responsible for pulling DNS Records from Route53. 

Quick TL:DR of how the task works:
- Task requires the user to provide an `AwsCredential` entity.
- Along with providing the AWS Credentials, the user can provide a `Hosted Zone ID`.
- If a `Hosted Zone ID` is provided, the task will only pull records from that specific Hosted Zone. If no `Hosted Zone ID` is provided, the task will pull records from all the available Hosted Zones it has access to.
- Once the resource record set is pulled from the Hosted Zone, the resource records will be iterated upon and an entity will be created for each respective record type.
- If the record type is a Nameserver -> Nameserver Entities will be created for the values of record (as they apply to the apex domain)
- If the record type is a MX -> Mailserver Entities will also be created for the values of the record (as the majority of the time these applied to the apex domain and are pointing to external servers; e.g. Google Workspaces)
- If the record type is either an A, AAAA, CNAME, or SRV -> DnsRecord Entity will be created for the **name** of the record.

Along with the above, exception handling has been implemented as well which will catch scenarios such as:
- Invalid Credentials
- Credentials lacking permissions
- etc.

Best regards,
Maxim