### PR TITLE
add a send_to_elasticsearch handler

### DIFF
--- a/lib/handlers/send_to_elasticsearch.rb
+++ b/lib/handlers/send_to_elasticsearch.rb
@@ -1,7 +1,14 @@
+
+###
+###
+###
 module Intrigue
-module Core
-module Handler
+  module Core
+  module Handler
+
   class SendToElasticsearch < Intrigue::Core::Handler::Base
+
+    SLICE_SIZE = 250
 
     def self.metadata
       {
@@ -14,63 +21,93 @@ module Handler
     def perform(result_type, result_id, prefix_name=nil)
       result = eval(result_type).first(id: result_id)
       return "Unable to process" unless result.respond_to? "export_json"
-      
+
       puts "Uploading entities to Elasticsearch!"
-      client = elasticsearch_client
-      
+      host = _get_handler_config("host")
+      port = _get_handler_config("port")
+      user = _get_handler_config("user")
+      pass = _get_handler_config("pass")
+      scheme = _get_handler_config("scheme")
+
+      es = ElasticsearchClient.new(host,port,user,pass,scheme)
+
       # upload entities
-      index_name = "#{prefix_name}#{result.name}-entities"
-      result.entities.paged_each(rows_per_fetch: 100) do |e|
-        begin
-          puts "Uploading entity #{e.type_string} #{e.name}"
-          client.index index: index_name, id: e.uuid, body: e.short_details.to_json
-        rescue Elasticsearch::Transport::Transport::Errors::BadRequest => ex
-          puts "ERROR Uploading entity #{e.type_string} #{e.name}"
-        end
+      result.entities.each_slice(SLICE_SIZE) do |slice|
+        es.store_bulk_slice_of_type(slice, "entities-#{result.name}")
       end
 
       # upload issues
-      index_name = "#{prefix_name}#{result.name}-issues"
-      result.issues.paged_each(rows_per_fetch: 100) do |i|
-        begin
-          puts "Uploading issue #{i.name}"
-          client.index index: index_name, id: i.uuid, body: i.export_json  
-        rescue Elasticsearch::Transport::Transport::Errors::BadRequest => ex
-          puts "ERROR Uploading issue #{i.name}"
-        end
+      result.issues.each_slice(SLICE_SIZE) do |slice|
+        es.store_bulk_slice_of_type(slice, "issues-#{result.name}")
       end
 
     end
-  
-    def elasticsearch_client
-      
-      endpoint = _get_handler_config("endpoint") || "http://localhost:9200/"
-      port = _get_handler_config("port") || 9200
-      
-      client = Elasticsearch::Client.new(url: endpoint, :port => port)
-      client.transport.reload_connections!
+  end
 
+  class ElasticsearchClient
 
-    client
+    def initialize(host,port,user=nil,pass=nil,scheme=nil)
+      @es_host = host
+      @es_port = port
+      @es_user = user
+      @es_pass = pass
+      @es_scheme = scheme || "http"
     end
 
-    #def to_bulk_json(entities_slice)
-    #
-    #  bulk_list = []
-    #  entities_slice.each do |e|
-    #    # two lines per
-    #    # https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-gsg-upload-data.html
-    #    bulk_list << {"index" => { "_id" => e.uid, "_index" => @index}}
-    #    bulk_list << e.to_hash
-    #  end
-    #  
-    #"#{bulk_list.map{|x| x["timestamp"] = nil; x.to_json}.join("\n")}" << "\n"
-    #end
+    def client
 
+      Elasticsearch::Client.new({
+        hosts:
+        [
+           {
+             host: @es_host || "localhost",
+             port: @es_port || "9200",
+             user: @es_user,
+             password: @es_pass,
+             scheme: @es_scheme
+           }
+        ]
+      })
 
+    end
 
+    def store_bulk_slice_of_type(slice, index_name)
+
+      # then store it!
+      begin
+        response = client.bulk body: slice_to_bulk_json(slice, index_name)
+        puts "Got errors in bulk response:#{JSON.pretty_generate(response)}" if response["errors"]
+      rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
+        puts "ERROR! Bad Request sending to ElasticSearch: #{e}"
+      rescue Elasticsearch::Transport::Transport::Error => e
+        puts "ERROR! Unable to connect to ElasticSearch: #{e}"
+      end
+    end
+
+    private
+
+    ##
+    ## helper method to convert a set of entities/issues/whatever will support .to_hash
+    ## into elasticsearch's bulk_json format
+    def slice_to_bulk_json(item_slice, index_name="entities")
+
+      ### conver tot format
+      bulk_list = []
+      item_slice.each do |i|
+        # two lines per
+        # https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-gsg-upload-data.html
+        bulk_list << {"index" => { "_id" => i.id, "_index" => index_name}}
+        bulk_list << i.to_hash
+      end
+
+      # return the bulk request we're going to make
+      out = bulk_list.map{|x| x.to_json }
+
+    "#{out.join("\n") }" << "\n"
+    end
 
   end
-end
-end
-end
+
+  end
+  end
+  end


### PR DESCRIPTION
Adds a handler that can send entities/issues to non-aws elasticsearch. relatively straightforward export, adds entities and issues into their own indicies. also much faster than previous ES handlers since it uses slices and the bulk api. 