### PR TITLE
More AWS Tasks Rework

### DIFF
--- a/lib/intrigue-tasks.rb
+++ b/lib/intrigue-tasks.rb
@@ -7,6 +7,8 @@ begin  # try to load runtime deps
   require 'aws-sdk-route53'
   require 'aws-sdk-s3'
   require 'aws-sdk-sqs'
+  require 'aws-sdk-iam'
+  require 'aws-sdk-ec2'
   require 'censys'
   require 'cloudflare'
   require 'compare-xml'

--- a/lib/tasks/aws_ec2_gather_instances.rb
+++ b/lib/tasks/aws_ec2_gather_instances.rb
@@ -1,64 +1,61 @@
 module Intrigue
-module Task
-class AwsEc2GatherInstances < BaseTask
-
-  def self.metadata
-    {
-      :name => "aws_ec2_gather_instances",
-      :pretty_name => "AWS EC2 Gather Instances",
-      :authors => ["jcran"],
-      :description => "This task enumerates machines running under an (authenticated) EC2 account.",
-      :references => [],
-      :type => "discovery",
-      :passive => true,
-      :allowed_types => ["AwsCredential"],
-      :example_entities => [{"type" => "String", "details" => {"name" => "intrigue"}}],
-      :allowed_options => [
-        {:name => "region", :regex => "alpha_numeric", :default => "us-east-1" }
-      ],
-      :created_types => ["IpAddress"]
-    }
-  end
-
-  ## Default method, subclasses must override this
-  def run
-    super
-
-    # Get the AWS Credentials
-    aws_access_key = @entity.details["hidden_access_id"]
-    aws_secret_key = @entity.details["hidden_secret_key"]
-
-    # Get the region
-    aws_region = _get_option "region"
-
-    begin
-      # Connect to AWS using fog ...
-      # TODO... prob want to remove the fog dep
-      ec2 = Fog::AWS::Compute.new({
-        :aws_access_key_id => aws_access_key,
-        :aws_secret_access_key => aws_secret_key,
-        :provider => "AWS",
-        :region => aws_region })
-
-      # "organization" => "#{ec2.arn.split(":")[4]}",
-      # Pull each server out and create an IPAddress
-      ec2.servers.each do |s|
-
-        _create_entity "IpAddress", {
-            "name" => "#{s.public_ip_address}",
-            "region" => "#{aws_region}",
-            "private_dns_name" => "#{s.private_dns_name}",
-            "private_ip_address" => "#{s.private_ip_address}",
-            "public_dns_name" => "#{s.dns_name}",
-            "ec2" => s.attributes.to_h
+  module Task
+    class AwsEc2GatherInstances < BaseTask
+      def self.metadata
+        {
+          name: 'aws_ec2_gather_instances',
+          pretty_name: 'AWS EC2 Gather Instances',
+          authors: ['jcran'],
+          description: 'This task enumerates machines running under an (authenticated) EC2 account.',
+          references: [],
+          type: 'discovery',
+          passive: true,
+          allowed_types: ['AwsCredential'],
+          example_entities: [{ 'type' => 'String', 'details' => { 'name' => 'intrigue' } }],
+          allowed_options: [
+            { name: 'region', regex: 'alpha_numeric', default: 'us-east-1' }
+          ],
+          created_types: ['IpAddress']
         }
       end
-    rescue Fog::Compute::AWS::Error => e
-      _log_error "Error: #{e}"
+
+      ## Default method, subclasses must override this
+      def run
+        super
+
+        # Get the AWS Credentials
+        aws_access_key = @entity.details['hidden_access_id']
+        aws_secret_key = @entity.details['hidden_secret_key']
+
+        # Get the region
+        aws_region = _get_option 'region'
+
+        begin
+          # Connect to AWS using fog ...
+          # TODO... prob want to remove the fog dep
+          ec2 = Fog::AWS::Compute.new({
+                                        aws_access_key_id: aws_access_key,
+                                        aws_secret_access_key: aws_secret_key,
+                                        provider: 'AWS',
+                                        region: aws_region
+                                      })
+
+          # "organization" => "#{ec2.arn.split(":")[4]}",
+          # Pull each server out and create an IPAddress
+          ec2.servers.each do |s|
+            _create_entity 'IpAddress', {
+              'name' => s.public_ip_address.to_s,
+              'region' => aws_region.to_s,
+              'private_dns_name' => s.private_dns_name.to_s,
+              'private_ip_address' => s.private_ip_address.to_s,
+              'public_dns_name' => s.dns_name.to_s,
+              'ec2' => s.attributes.to_h
+            }
+          end
+        rescue Fog::Compute::AWS::Error => e
+          _log_error "Error: #{e}"
+        end
+      end
     end
-
   end
-
-end
-end
 end

--- a/lib/tasks/aws_ec2_gather_instances.rb
+++ b/lib/tasks/aws_ec2_gather_instances.rb
@@ -5,13 +5,13 @@ module Intrigue
         {
           name: 'aws_ec2_gather_instances',
           pretty_name: 'AWS EC2 Gather Instances',
-          authors: ['jcran'],
+          authors: ['jcran', 'maxim'],
           description: 'This task enumerates machines running under an (authenticated) EC2 account.',
           references: [],
           type: 'discovery',
           passive: true,
           allowed_types: ['AwsCredential'],
-          example_entities: [{ 'type' => 'String', 'details' => { 'name' => 'intrigue' } }],
+          example_entities: [{ 'type' => 'String', 'details' => { 'name' => 'AKIAOKZ52BOMZQ9WNUZ2:zc3w4zt5TU0/ItZ+OlzvaIdytJEz352fzH21ZonO9' } }],
           allowed_options: [
             { name: 'region', regex: 'alpha_numeric', default: 'us-east-1' }
           ],
@@ -26,36 +26,45 @@ module Intrigue
         # Get the AWS Credentials
         aws_access_key = @entity.details['hidden_access_id']
         aws_secret_key = @entity.details['hidden_secret_key']
-
-        # Get the region
         aws_region = _get_option 'region'
 
-        begin
-          # Connect to AWS using fog ...
-          # TODO... prob want to remove the fog dep
-          ec2 = Fog::AWS::Compute.new({
-                                        aws_access_key_id: aws_access_key,
-                                        aws_secret_access_key: aws_secret_key,
-                                        provider: 'AWS',
-                                        region: aws_region
-                                      })
+        ec2 = Aws::EC2::Resource.new(region: aws_region, access_key_id: aws_access_key, secret_access_key: aws_secret_key)
 
-          # "organization" => "#{ec2.arn.split(":")[4]}",
-          # Pull each server out and create an IPAddress
-          ec2.servers.each do |s|
-            _create_entity 'IpAddress', {
-              'name' => s.public_ip_address.to_s,
-              'region' => aws_region.to_s,
-              'private_dns_name' => s.private_dns_name.to_s,
-              'private_ip_address' => s.private_ip_address.to_s,
-              'public_dns_name' => s.dns_name.to_s,
-              'ec2' => s.attributes.to_h
-            }
-          end
-        rescue Fog::Compute::AWS::Error => e
-          _log_error "Error: #{e}"
+        begin
+          instances = ec2.instances
+          instances.first # force to authenticate to ensure creds are valid
+        rescue Aws::EC2::Errors::AuthFailure
+          _log_error 'Invalid AWS Keys.'
+          nil
+        rescue Aws::EC2::Errors::UnauthorizedOperation
+          _log_error 'API Key lacks permission to list instances.'
+          nil
+        rescue Seahorse::Client::NetworkingError
+          _log_error "Unable to connect to the AWS EC2 API, this is most likely because #{aws_region} is an invalid region."
+          return nil
+        end
+
+        unless instances.count.positive?
+          _log "No EC2 instances were discovered in #{aws_region}!"
+          return nil
+        end
+
+        create_entities instances
+      end
+
+      def create_entities(ec2_instances)
+        ec2_instances.each do |instance|
+          _create_entity 'IpAddress', {
+            'name' => instance.public_ip_address.nil? ? '0.0.0.0' : instance.public_ip_address,
+            'region' => instance.placement.availability_zone.chop,
+            'availability_zone' => instance.placement.availability_zone,
+            'private_dns_name' => instance.private_dns_name,
+            'private_ip_address' => instance.private_ip_address,
+            'public_dns_name' => instance.public_ip_address
+          }
         end
       end
+
     end
   end
 end

--- a/lib/tasks/aws_iam_gather_accounts.rb
+++ b/lib/tasks/aws_iam_gather_accounts.rb
@@ -30,10 +30,10 @@ module Intrigue
         begin
           groups = iam.list_groups
           users = iam.list_users
-        rescue Aws::Route53::Errors::InvalidClientTokenId
+        rescue Aws::IAM::Errors::InvalidClientTokenId
           _log_error 'Invalid Access Key ID.'
           return nil
-        rescue Aws::Route53::Errors::SignatureDoesNotMatch
+        rescue Aws::IAM::Errors::SignatureDoesNotMatch
           _log_error 'Secret Access Key does not match Access Key ID.'
           return nil
         rescue Aws::IAM::Errors::AccessDenied

--- a/lib/tasks/aws_iam_gather_accounts.rb
+++ b/lib/tasks/aws_iam_gather_accounts.rb
@@ -1,85 +1,82 @@
 module Intrigue
-module Task
-class AwsIamGatherAccounts < BaseTask
-
-  def self.metadata
-    {
-      :name => "aws_iam_gather_accounts",
-      :pretty_name => "AWS IAM Gather Accounts",
-      :authors => ["jcran"],
-      :description => "Given AWS creds, this task enumerates aws iam accounts.",
-      :references => [],
-      :type => "discovery",
-      :passive => true,
-      :allowed_types => ["AwsCredential"],
-      :example_entities => [{"type" => "String", "details" => {"name" => "intrigue"}}],
-      :allowed_options => [
-        {:name => "region", :regex => "alpha_numeric", :default => "us-east-1" }
-      ],
-      :created_types => ["AwsIamAccount"]
-    }
-  end
-
-  ## Default method, subclasses must override this
-  def run
-    super
-
-    # Get the AWS Credentials
-    aws_access_key = @entity.details["hidden_access_id"]
-    aws_secret_key = @entity.details["hidden_secret_key"]
-
-    # Get the region
-    aws_region = _get_option "region"
-
-    begin
-      # Connect to AWS using fog ...
-      # TODO... prob want to remove the fog dep
-      connection = Fog::AWS::IAM.new({
-        :aws_access_key_id => aws_access_key,
-        :aws_secret_access_key => aws_secret_key,
-        :region => aws_region })
-
-      # Create groups
-      connection.groups.each do |g| 
-        groupname = "#{g.arn}".split(":")[5]
-        _log "Got: #{groupname}"
-
-        # Create the entity
-        _create_entity "AwsIamAccount", { 
-          "account_type" => "group", 
-          "region" => aws_region,
-          "name" => groupname, 
-          "organization" => "#{g.arn}".split(":")[4], 
-          "arn" => "#{g.arn}", 
-          "id" => g.id
+  module Task
+    class AwsIamGatherAccounts < BaseTask
+      def self.metadata
+        {
+          name: 'aws_iam_gather_accounts',
+          pretty_name: 'AWS IAM Gather Accounts',
+          authors: ['jcran'],
+          description: 'Given AWS creds, this task enumerates aws iam accounts.',
+          references: [],
+          type: 'discovery',
+          passive: true,
+          allowed_types: ['AwsCredential'],
+          example_entities: [{ 'type' => 'String', 'details' => { 'name' => 'intrigue' } }],
+          allowed_options: [
+            { name: 'region', regex: 'alpha_numeric', default: 'us-east-1' }
+          ],
+          created_types: ['AwsIamAccount']
         }
       end
 
-      # Create Users
-      connection.users.each do |u| 
-        username = "#{u.arn}".split(":")[5]
-        _log "Got: #{username}"
+      ## Default method, subclasses must override this
+      def run
+        super
 
-        # Create the entity
-        # TODO .. should be associated with a credential (for enrichment)
-        _create_entity "AwsIamAccount", {  
-          "account_type" => "user", 
-          "name" => username, 
-          "region" => aws_region,
-          "path" => "#{u.path}",
-          "organization" => "#{u.arn}".split(":")[4], 
-          "arn" => "#{u.arn}", 
-          "id" => u.id,
-          "created_at" => "#{u.created_at}"
-        }
+        # Get the AWS Credentials
+        aws_access_key = @entity.details['hidden_access_id']
+        aws_secret_key = @entity.details['hidden_secret_key']
+
+        # Get the region
+        aws_region = _get_option 'region'
+
+        begin
+          # Connect to AWS using fog ...
+          # TODO... prob want to remove the fog dep
+          connection = Fog::AWS::IAM.new({
+                                           aws_access_key_id: aws_access_key,
+                                           aws_secret_access_key: aws_secret_key,
+                                           region: aws_region
+                                         })
+
+          # Create groups
+          connection.groups.each do |g|
+            groupname = g.arn.to_s.split(':')[5]
+            _log "Got: #{groupname}"
+
+            # Create the entity
+            _create_entity 'AwsIamAccount', {
+              'account_type' => 'group',
+              'region' => aws_region,
+              'name' => groupname,
+              'organization' => g.arn.to_s.split(':')[4],
+              'arn' => g.arn.to_s,
+              'id' => g.id
+            }
+          end
+
+          # Create Users
+          connection.users.each do |u|
+            username = u.arn.to_s.split(':')[5]
+            _log "Got: #{username}"
+
+            # Create the entity
+            # TODO .. should be associated with a credential (for enrichment)
+            _create_entity 'AwsIamAccount', {
+              'account_type' => 'user',
+              'name' => username,
+              'region' => aws_region,
+              'path' => u.path.to_s,
+              'organization' => u.arn.to_s.split(':')[4],
+              'arn' => u.arn.to_s,
+              'id' => u.id,
+              'created_at' => u.created_at.to_s
+            }
+          end
+        rescue Fog::AWS::IAM::Error => e
+          _log_error "Error: #{e}"
+        end
       end
-
-    rescue Fog::AWS::IAM::Error => e
-      _log_error "Error: #{e}"
     end
-
   end
-
-end
-end
 end


### PR DESCRIPTION
Hi team,

Please find attached in this PR the following AWS tasks which were rewritten:
- EC2 Gather Instances
- IAM Gather Accounts

#### EC2 Gather Instances
Key Changes:
- Using the official AWS EC2 Ruby SDK instead of Fog.
- More exception handling, examples including:
    - Invalid AWS Credentials
    - AWS Credentials lacking permission to retrieve instances.
    - Invalid region provided.
    - Fixed the bug where the entity would not be created due to the Public IP Address being returned as nil. This occurs in cases where the EC2 instance is offline when not using an Elastic IP Address or in scenarios where the instance lacks a public IP Address due to being in a private subnet in a VPC (in cases where it is behind a Load Balancer, Cloudfront, etc.)
    
    **Note**: In the above scenario, the task is setting a 'blackhole' IP Address of 0.0.0.0. This is due to the IP Address entity 
requiring an address which matches an IP Address Regex. However as this use case scenario is so rare, I felt that using 0.0.0.0 is a better idea instead of modifying the entity. Plus as it would treat it as 0.0.0.0/32 there seems to be no harm (as in it won't scan the whole Internet like if it was 0.0.0.0/0).

#### IAM Gather Accounts
Key Changes:
- Using the official AWS IAM Ruby SDK instead of Fog.
- More exception handling (same as the above EC2 task).
- Region is removed from the created entity (and the task) as IAM is global and not based on regions.

Best regards,
Maxim