### PR TITLE
improve URI auth checking

### DIFF
--- a/lib/tasks/enrich/uri.rb
+++ b/lib/tasks/enrich/uri.rb
@@ -177,6 +177,15 @@ class Uri < Intrigue::Task::BaseTask
     _log "Checking if Authenticated"
     contains_auth = check_auth(ident_content)
 
+    _log "Checking if Authenticated (basic auth)"
+    contains_auth_basic = check_auth_by_type(ident_content, "Authentication - HTTP")
+
+    _log "Checking if Authenticated (ntlm auth)"
+    contains_auth_ntlm = check_auth_by_type(ident_content, "Authentication - NTLM")
+
+    _log "Checking if Authenticated (forms auth)"
+    contains_auth_forms = check_auth_by_type(ident_content, "Authentication - Forms")
+
     # we can check the existing response, so send that
     _log "Checking if 2FA Identified"
     contains_auth_2fa = check_auth_2fa(ident_content)
@@ -317,6 +326,9 @@ class Uri < Intrigue::Task::BaseTask
     new_details = {
       "alt_names" => alt_names,
       "auth.any" => contains_auth,
+      "auth.basic" => contains_auth_basic,
+      "auth.forms" => contains_auth_forms,
+      "auth.ntlm" => contains_auth_ntlm,
       "auth.2fa" => contains_auth_2fa,
       "code" => response.code,
       "cookies" => set_cookie,
@@ -447,7 +459,18 @@ class Uri < Intrigue::Task::BaseTask
   # checks to see if we had an auth config return true
   def check_auth(configuration)
     configuration.each do |c|
-      if "#{c["name"]}".match(/^Auth\ \-.*$/) && "#{c["value"]}".to_bool
+      if "#{c["name"]}".match(/^Authentication\ \-.*$/) && "#{c["value"]}".to_bool
+        return true
+      end
+    end
+  false
+  end
+
+
+  # checks to see if we had an auth config return true
+  def check_auth_by_type(configuration, auth_type)
+    configuration.each do |c|
+      if "#{c["name"]}" == auth_type && "#{c["value"]}".to_bool
         return true
       end
     end
@@ -457,7 +480,8 @@ class Uri < Intrigue::Task::BaseTask
   # checks to see if we had an auth config return true
   def check_auth_2fa(fingerprint)
     fingerprint.each do |fp|
-      if (fp["tags"]||[]).map(&:upcase).include?(["IAM","SSO","MFA","2FA"])
+      # check the intersection of these
+      if ( (fp["tags"]||[]).map(&:upcase) & ["IAM","SSO","MFA","2FA"] ).any?
         return true
       end
     end


### PR DESCRIPTION
This PR fixes an issue in how we check for authentication (based on underlying checks from ident), and adds a few more attributes so users can get super granular in how they want to filter endpoints with any or all authentication. 

Note that the 2FA stuff may need a bit more tweaking based on current tag work in ident, cc @shpendk 
