### PR TITLE
cisco cve and issues creation for network services

### DIFF
--- a/lib/issues/cisco_smartinstall_cve_2018_0151.rb
+++ b/lib/issues/cisco_smartinstall_cve_2018_0151.rb
@@ -1,0 +1,26 @@
+module Intrigue
+  module Issue
+    class CiscoSmartInstallRceCve20180151 < BaseIssue
+      def self.generate(instance_details={})
+        {
+          added: "2021-05-18",
+          pretty_name: "Cisco Smart Install Remote Code Execution (CVE-2018-0151)",
+          name: "cisco_smartinstall_cve_2018_0151",
+          category: "vulnerability",
+          severity: 1,
+          status: "potential",
+          description: "Cisco Smart Install Remote Code Execution Vulnerability",
+          remediation: "Update the device.",
+          affected_software: [
+            { :vendor => "Cisco", :product => "Smart Install" }
+          ],
+          references: [ # types: description, remediation, detection_rule, exploit, threat_intel
+            { type: "description", uri: "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180328-qos" }, 
+            { type: "description", uri: "https://nvd.nist.gov/vuln/detail/CVE-2018-0151" },
+            { type: "description", uri: "https://www.rapid7.com/blog/post/2018/03/29/cisco-smart-install-smi-remote-code-execution-what-you-need-to-know/" }
+          ]
+        }.merge(instance_details)
+      end
+    end
+  end
+end

--- a/lib/tasks/enrich/network_service.rb
+++ b/lib/tasks/enrich/network_service.rb
@@ -61,6 +61,13 @@ class NetworkService < Intrigue::Task::BaseTask
     # Create issues for any vulns that are version-only inference
     fingerprint_to_inference_issues(fingerprint)
 
+    # Create issues for fingerprints that request creating an issue
+    issues_from_fingerprints = fingerprint.collect{ |x| x["issues"] }.flatten.compact.uniq
+    _log "Issues to be created: #{issues_from_fingerprints}"  
+    (issues_from_fingerprints || []).each do |c|
+        _create_linked_issue c
+    end
+
     # Okay, now kick off vulnerability checks (if project allows)
     if @project.vulnerability_checks_enabled
       vuln_checks = run_vuln_checks_from_fingerprint(fingerprint, @entity)


### PR DESCRIPTION
Issue for cisco cve and issue creation. I realized that for network services, we don't create issues specified via `issue: []` in the fingerprint. I added that here too.