### PR TITLE
task config improvement

### DIFF
--- a/config/config.json.default
+++ b/config/config.json.default
@@ -58,7 +58,14 @@
       "uri": "http://127.0.0.1:9999/"
     }
   },
-  "intrigue_global_machine_config": {},
+  "intrigue_global_machine_config": {
+    "platform_credentials_api_key": {
+      "value": "",
+      "uri": "https://api.intrigue.io/integrations/credentials",
+      "editable": "true",
+      "comment": ""
+    }
+  },
   "intrigue_global_module_config": {
     "42matters_api_key": {
       "value": "",

--- a/lib/tasks/helpers/generic.rb
+++ b/lib/tasks/helpers/generic.rb
@@ -168,15 +168,38 @@ module Generic
   end
 
   def _get_task_config(key)
-    begin
 
+    # if in prod, check platform api
+    if ENV["APP_ENV"] == "production-engine"
+      # go to platform api and obtain credentials
+      url = Intrigue::Core::System::Config.config["intrigue_global_machine_config"]["platform_credentials_api_key"]["uri"]
+      access_key = Intrigue::Core::System::Config.config["intrigue_global_machine_config"]["platform_credentials_api_key"]["value"]
+
+      res = http_request :get,"#{url}?access_key=#{access_key}&key=#{key}"
+      if res.response_code == 200
+        return res.body_utf8
+      end
+
+    end
+
+    # if exposed as ENV variable, use that
+    if ENV[key]
+      return ENV[key]
+    end
+
+    # use the config.json file
+    begin
       Intrigue::Core::System::Config.load_config
       error_message = "Please enter your #{key} setting in 'Configure -> Task Configuration'"
       config = Intrigue::Core::System::Config.config["intrigue_global_module_config"]
-      value = config[key]["value"]
+      if config.key?(key)
+        value = config[key]["value"]
 
-      unless value && value != ""
-        raise MissingTaskConfigurationError.new error_message
+        unless value && value != ""
+          raise MissingTaskConfigurationError.new error_message
+        end
+      else
+        raise MissingTaskConfigurationError.new "No configuration with name #{key} found."
       end
 
     end


### PR DESCRIPTION
this PR improves `_get_task_config` so that when a key is requested, the following procedure is followed:
1st: (for production engines) it queries our platform api. If this fails or we're not in prod continue to 2nd.
2nd: It will check environment variables for the key. If found, value is returned. Otherwise continue to 3rd.
3rd: Check config.json and return value if key is found. Otherwise throw error.