### PR TITLE
Fix nil reference being thrown in subdomain_hijack

### DIFF
--- a/lib/tasks/uri_check_subdomain_hijack.rb
+++ b/lib/tasks/uri_check_subdomain_hijack.rb
@@ -198,7 +198,7 @@ class UriCheckSudomainHijack  < BaseTask
       #  _create_hijackable_subdomain_issue("Statuspage", uri, "potential") unless (
       #    uri =~ /statuspage.com/ || uri =~ /statuspage.io/ || uri =! /amazonaws.com/)
 
-      elsif response_body.match /Page not found \- Strikingly/i && uri =~ /strikinglydns.com/
+      elsif response_body.match(/Page not found \- Strikingly/i) && uri =~ /strikinglydns.com/
         _create_hijackable_subdomain_issue "Strikingly", uri, "potential"
 
       #elsif response_body.match /We can\'t find this \<a href=\"https\:\/\/simplebooklet\.com/i


### PR DESCRIPTION
Hi team,

Noticed this when was reviewing the stacktraces from a recent scan.

Due to the parenthesis missing, the .match logic was incorporating the second comparison and thus throwing an error. 

Best regards,
Maxim