### PR TITLE
Fix enrichment notracecondition

### DIFF
--- a/lib/checks/solarwinds_servu_CVE_2021_35211.rb
+++ b/lib/checks/solarwinds_servu_CVE_2021_35211.rb
@@ -1,0 +1,55 @@
+module Intrigue
+  module Issue
+    class SolarwindsServuCve202135211 < BaseIssue
+      def self.generate(instance_details = {})
+        {
+          added: '2021-07-13',
+          name: 'solarwinds_servu_CVE_2021_35211.rb',
+          pretty_name: 'SolarWinds Serv-U Remote Code Execution (CVE-2021-35211)',
+          identifiers: [
+            { type: 'CVE', name: 'CVE-2021-35211' }
+          ],
+          severity: 1,
+          category: 'vulnerability',
+          status: 'potential',
+          description: 'Remote code execution vulnerability in Serv-U 15.2.3 HF1 and all prior Serv-U versions',
+          affected_software: [
+            { vendor: 'SolarWinds', product: 'Serv-U' }
+          ],
+          references: [
+            { type: 'description', uri: 'https://nvd.nist.gov/vuln/detail/CVE-2021-35211' },
+            { type: 'description',
+              uri: 'https://www.helpnetsecurity.com/2021/07/13/solarwinds-patches-zero-day-exploited-in-the-wild-cve-2021-35211/' }
+          ],
+          authors: ['shpendk']
+        }.merge!(instance_details)
+      end
+    end
+  end
+
+  module Task
+    class SolarwindsServuCve202135211 < BaseCheck
+      def self.check_metadata
+        {
+          # Serv-U is not affected if ssh is enabled, hence only URI accepted here (see helpnetsecurity description for more details)
+          allowed_types: ['Uri'] 
+        }
+      end
+
+      # return truthy value to create an issue
+      def check
+        # get enriched entity
+        require_enrichment
+
+        # get version for product
+        version = get_version_for_vendor_product(@entity, 'SolarWinds', 'Serv-U')
+        return false unless version
+
+        # if its vulnerable, return some proof
+        if compare_versions_by_operator(version, '15.2.3', '<=')
+          return "Asset is vulnerable based on fingerprinted version #{version}"
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/base.rb
+++ b/lib/tasks/base.rb
@@ -218,13 +218,13 @@ class BaseTask
         # do this in a transaction so we don't accidentally miss one completing in another thread
         $db.transaction do
           # get it
+          @entity = Intrigue::Core::Model::Entity.find(:id => @entity.id)
           etc = @entity.enrichment_tasks_completed
           etc << @task_result.task_name
           # set it
           @entity.enrichment_tasks_completed = etc
           @entity.save
         end
-
         # now check it
         is_fully_enriched = @entity.enrichment_tasks_completed.count == @entity.enrichment_tasks.count
         puts "DEBUG: Checking if fully enriched: #{@task_result.task_name} (#{is_enrichment_task})"


### PR DESCRIPTION
This small change fixes a bug that would fail to run tasks that have `require_enrichment`, and the entity type has more than 1 enrichment tasks. Although the changes to the entity are handled in a transaction, for some reason, the variable `@entity` would not get updated if another task sets `@entity.enrichment_tasks_completed = etc`(line 219 - 226 in lib/tasks/base.rb). Therefore, the condition in line 229 in file lib/tasks/base.rb would never fulfil:
```
is_fully_enriched = @entity.enrichment_tasks_completed.count == @entity.enrichment_tasks.count
```
As a result, the entity is never marked fully enriched, and any tasks that have `require_enrichment` fail to run.

The solution was to reload the `@entity` variable through `Intrigue::Core::Model::Entity.find`. There may be better ways, but this one definitely solves the problem. 