### PR TITLE
Update AWS S3 Bucket Path Style Regex

### DIFF
--- a/lib/tasks/helpers/aws.rb
+++ b/lib/tasks/helpers/aws.rb
@@ -53,7 +53,7 @@ module Intrigue
         ## Path Style -> being deprecated soon; adding in for legacy support
         # https://s3.amazonaws.com/bucketname
         # s3.amazonaws.com/bucketname
-        path_style_regex = /(?:https:\/\/)?s3\.amazonaws\.com\/(.+)\/(?:.+)?/
+        path_style_regex = /(?:https:\/\/)?s3\.amazonaws\.com\/([\w\.\-]+)/
 
         case bucket_url
         when virtual_style_regex


### PR DESCRIPTION
Hi team,

Please find in this pull request updates to the `AWS S3 Bucket Path Style Regex`.

Along with fixing the annoying warning message that Ruby would spit out upon starting Core, this also fixes a small bug in where if the bucket name didn't contain a key it wouldn't be extracted.

However the new regex works well and here are a few tests which confirm this:
https://rubular.com/r/z6UGvLaqAQKVIu

Best regards,
Maxim

