### PR TITLE
COR 149 - Hide URI Entities if Response Code 0

### DIFF
--- a/lib/tasks/enrich/uri.rb
+++ b/lib/tasks/enrich/uri.rb
@@ -39,6 +39,13 @@ class Uri < Intrigue::Task::BaseTask
     response = http_request :get, uri
     response2 = http_request :get, uri
 
+    if [response.code, response2.code].all? { |code| code == '0' }
+      _log_error "Unable to reach #{uri}, bailing"
+      @entity.hidden = true
+      @entity.save_changes
+      return # no point in doing additional logic
+    end
+
     unless response && response2 && response.body_utf8
       _log_error "Unable to receive a response for #{uri}, bailing"
       return


### PR DESCRIPTION
Hi team,

This PR introduces a fix which hides URI entities when a status code of `0` is returned. This behavior stems from `Typhoeus` and it occurs when the request times out; e.g non-existent website, invalid proxy used, etc.

Upon a status code of `0` being returned, the entity is hidden and the enrich task is stopped. There seems to be no point further enriching a URI which returns a status code of `0` similar to the logic of the conditional right below it which performs the same behavior if an invalid response is returned.

Best regards,
Maxim

