### PR TITLE
Handle Connection Reset Error when attempting to obtain SSL Certificate

### DIFF
--- a/lib/tasks/helpers/services.rb
+++ b/lib/tasks/helpers/services.rb
@@ -18,8 +18,8 @@ module Services
     begin 
       # connect
       socket = connect_ssl_socket(hostname,port,timeout)
-    rescue OpenSSL::SSL::SSLError => e 
-      _log_error "Unable to connnect ssl certificate"
+    rescue OpenSSL::SSL::SSLError, Errno::ECONNRESET
+      _log_error 'Unable to connnect to ssl certificate'
     end
     
     return nil unless socket && socket.peer_cert
@@ -63,7 +63,7 @@ module Services
       # connect, grab the socket and make sure we
       # keep track of these details, and create entitie
       cert = get_certificate(ip_entity.name,port_num)
-
+      
       if cert 
         
         # grabs cert names, if not a universal cert 


### PR DESCRIPTION
Hi team,

Please find in this PR the fix for the unhandled exception: `Errno::ECONNRESET: Connection reset by peer - SSL_connect`

I've noticed this would tend to occur after the `naabu_scan` task would call the `_create_network_service_entity` helper method on a IP Address entity where Port 443 was detected. The helper method then in-turn would call `get_certificate` which would throw the error.

Best regards,
Maxim