### PR TITLE
Remove hidden entity details

### DIFF
--- a/lib/tasks/enrich/uri.rb
+++ b/lib/tasks/enrich/uri.rb
@@ -349,7 +349,6 @@ class Uri < Intrigue::Task::BaseTask
       "forms" => contains_forms,
       "generator" => generator_string,
       "headers" => headers,
-      "hidden_response_data" => response.body_utf8,
       "redirect_chain" => ident_responses.first[:response_urls] || [],
       "response_data_hash" => response_data_hash,
       "dom_sha1" => dom_sha1,
@@ -403,7 +402,7 @@ class Uri < Intrigue::Task::BaseTask
 
         # if we made it this far, parse them & compare them
         # TODO ... is this overkill?
-        their_doc = e.details["hidden_response_data"]
+        their_doc = e.details["extended_response_body"]
         diffs = parse_html_diffs(our_doc, their_doc)
         their_doc = nil
 

--- a/lib/tasks/helpers/web_content.rb
+++ b/lib/tasks/helpers/web_content.rb
@@ -15,7 +15,7 @@ module WebContent
   dom_string
   end
 
-  # compare_html response.body_utf8.sanitize_unicode, e.details["hidden_response_data"]  
+  # compare_html response.body_utf8.sanitize_unicode, e.details["extended_response_body"]  
   def parse_html_diffs(texta, textb)
     # parse our content with Nokogiri
     our_doc = Nokogiri::HTML(texta)

--- a/lib/tasks/uri_browser_analysis.rb
+++ b/lib/tasks/uri_browser_analysis.rb
@@ -136,7 +136,7 @@ module Intrigue
           end
 
           # now merge them together and set as the new details
-          _get_and_set_entity_details browser_data_hash
+          # _get_and_set_entity_details browser_data_hash
         end
       end
     end

--- a/lib/tasks/wordpress_enumerate_plugins.rb
+++ b/lib/tasks/wordpress_enumerate_plugins.rb
@@ -40,7 +40,7 @@ class WordpressEnumeratePlugins < BaseTask
   end # end run()
 
   def extract_wordpress_plugin_paths(uri)
-    page_content = _get_entity_detail("hidden_response_data")
+    page_content = _get_entity_detail("extended_response_body")
     extract_plugins_regex = /\/wp-content\/plugins\/(.*?)\//
     plugins = []
     match_captures = page_content.scan(extract_plugins_regex)


### PR DESCRIPTION
Remove any hidden_* entity detail from entities. Also don't append browser_* attributes. Both of these significantly reduce the size of the entity.