### PR TITLE
Small Bug Fixes

### DIFF
--- a/lib/tasks/iis_shortname_scanner.rb
+++ b/lib/tasks/iis_shortname_scanner.rb
@@ -70,14 +70,18 @@ module Intrigue
       # is_iis? -> determines if the target host is running IIS in order to cut down on false positives
       def is_iis?
         found_iss = false
+
         fp = _get_entity_detail("fingerprint")
+        return found_iss if fp.nil?
+
         fp.each do |f|
           if f["vendor"] == "Microsoft" && f["product"] == "Internet Information Services"
             found_iss = true
             break
           end
         end
-        return found_iss
+
+        found_iss
       end
 
       ##

--- a/lib/tasks/saas_servicenow_check.rb
+++ b/lib/tasks/saas_servicenow_check.rb
@@ -27,7 +27,7 @@ class SaasServicenowCheck < BaseTask
     if _get_entity_type_string == "WebAccount"
       account_name = _get_entity_detail("username")
     else
-      account_name = "#{_get_entity_name}".santize_unicode
+      account_name = "#{_get_entity_name}".sanitize_unicode
     end
 
     # try a couple variations

--- a/lib/tasks/search_wayback_machine.rb
+++ b/lib/tasks/search_wayback_machine.rb
@@ -32,7 +32,7 @@ module Intrigue
         hosts = json.flatten.map do |record|
           URI.parse(record).host
         rescue URI::InvalidURIError
-          log_error "Unable to parse entity: #{record}. Skipping."
+          _log_error "Unable to parse entity: #{record}. Skipping."
           next
         end
 


### PR DESCRIPTION
Hi team,

Please find attached in this PR various bug fixes that were discovered when running a scan.

`lib/tasks/iis_shortname_scanner.rb` -> Check if the returned fingerprint is nil. This appears to happen to hosts where the SSL certificate is self-signed or expired (and is stemming from that previous bug in curl which is being mitigated) thus causing the enrich task to bail out early therefore not returning a fingerprint. However in the meantime it doesn't hurt to add a check which will handle the exception.

`lib/tasks/saas_servicenow_check.rb` -> Fixed typo changing `santize_unicode` to  `sanitize_unicode`

`lib/tasks/search_wayback_machine.rb` -> Fixed typo changing `log_error` to `_log_error`

Thanks.

Best regards,
Maxim