### PR TITLE
Cloudcreds entities

### DIFF
--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -262,11 +262,30 @@ module Model
       details[key]
     end
 
+    def get_sensitive_detail(key)
+      return nil unless self.sensitive_details
+      sensitive_details[key]
+    end
+
     def set_detail(key, value)
       begin
         $db.transaction do
           refresh
           self.set(:details => details.merge({key => value}.sanitize_unicode))
+          save
+        end
+      rescue Sequel::NoExistingObject => e
+        puts "Error saving details for #{self}: #{e}, deleted?"
+      rescue Sequel::DatabaseError => e
+        puts "Error saving details for #{self}: #{e}, deleted?"
+      end
+    end
+
+    def set_sensitive_detail(key, value)
+      begin
+        $db.transaction do
+          refresh
+          self.set(:sensitive_details => sensitive_details.merge({key => value}.sanitize_unicode))
           save
         end
       rescue Sequel::NoExistingObject => e
@@ -290,6 +309,20 @@ module Model
         $db.transaction do
           refresh
           self.set(:details => new_details.sanitize_unicode)
+          save_changes
+        end
+      rescue Sequel::NoExistingObject => e
+        puts "Error saving details for #{self}: #{e}, deleted?"
+      rescue Sequel::DatabaseError => e
+        puts "Error saving details for #{self}: #{e}, deleted?"
+      end
+    end
+
+    def set_sensitive_details(new_details)
+      begin
+        $db.transaction do
+          refresh
+          self.set(:sensitive_details => new_details.sanitize_unicode)
           save_changes
         end
       rescue Sequel::NoExistingObject => e

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -15,7 +15,7 @@ module Model
 
   class Entity < Sequel::Model
     plugin :validation_helpers
-    plugin :serialization, :json, :enrichment_tasks_completed
+    plugin :serialization, :json, :enrichment_tasks_completed, :sensitive_details
     plugin :single_table_inheritance, :type
     plugin :timestamps
 
@@ -108,11 +108,7 @@ module Model
     end
 
     def sensitive?
-      if self.class.metadata.key?(:sensitive)
-        return self.class.metadata[:sensitive] || false
-      else
-        return false
-      end
+      self.class.metadata[:sensitive] || false
     end
 
     def validate
@@ -125,13 +121,11 @@ module Model
     end
 
     def short_details # ideally this is just excluding extended_ stuff
-      return {"Note" => "Details hidden because sensitive"} unless !self.sensitive?
       details.reject{ |k,v|
         k.to_s.match(/^hidden_.*$/) || k.to_s.match(/^extended_.*$/) || k.to_s.match(/^encoded_.*$/)  }
     end
 
     def extended_details # ideally this is just including extended_ stuff
-      return {"Note" => "Details hidden because sensitive"} unless !self.sensitive?
       details.select{ |k,v|
         k.to_s.match(/^hidden_.*$/) || k.to_s.match(/^extended_.*$/)|| k.to_s.match(/^encoded_.*$/) }
     end
@@ -280,10 +274,6 @@ module Model
       rescue Sequel::DatabaseError => e
         puts "Error saving details for #{self}: #{e}, deleted?"
       end
-    end
-
-    def get_details
-      details
     end
 
     def get_and_set_details(new_details={})

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -107,6 +107,14 @@ module Model
     false
     end
 
+    def sensitive?
+      if self.class.metadata.key?(:sensitive)
+        return self.class.metadata[:sensitive] || false
+      else
+        return false
+      end
+    end
+
     def validate
       super
       validates_unique([:project_id, :type, :name])
@@ -117,11 +125,13 @@ module Model
     end
 
     def short_details # ideally this is just excluding extended_ stuff
+      return {"Note" => "Details hidden because sensitive"} unless !self.sensitive?
       details.reject{ |k,v|
         k.to_s.match(/^hidden_.*$/) || k.to_s.match(/^extended_.*$/) || k.to_s.match(/^encoded_.*$/)  }
     end
 
     def extended_details # ideally this is just including extended_ stuff
+      return {"Note" => "Details hidden because sensitive"} unless !self.sensitive?
       details.select{ |k,v|
         k.to_s.match(/^hidden_.*$/) || k.to_s.match(/^extended_.*$/)|| k.to_s.match(/^encoded_.*$/) }
     end

--- a/core-cli.rb
+++ b/core-cli.rb
@@ -138,7 +138,7 @@ class CoreCli < Thor
   desc "local_handle_project [Project] [Handler] [Prefix (optional)]", "Manually run a handler on a project's scan results"
   def local_handle_project(project, handler_type, prefix=nil)
     puts "Working on project #{project}..."
-    Intrigue::Core::Model::Project.first(:name => project).handle(handler_type, prefix)
+    Intrigue::Core::Model::Project.first(:name => project).handle_synchronous(handler_type, prefix)
   end
 
   desc "local_handle_scan_results [Project] [Handler] [Prefix (optional)]", "Manually run a handler on a project's scan results"

--- a/core-cli.rb
+++ b/core-cli.rb
@@ -10,6 +10,10 @@ class CoreCli < Thor
 
   include Intrigue::Core::System
 
+  def _log(msg)
+    puts "[Log] - #{msg}"
+  end 
+
   def initialize(*args)
     super
     $intrigue_basedir = File.dirname(__FILE__)
@@ -267,30 +271,33 @@ private
 
   # parse out entity from the cli
   def _parse_entity(entity_string)
-    # check and return nil if the first char is a "#"
-    return nil if entity_string[0] == "#"
+    if entity_string.class == Hash
+      return Intrigue::Core::System::Bootstrap::_parse_entity_hash(entity_string)
+    else
+      # check and return nil if the first char is a "#"
+      return nil if entity_string[0] == "#"
 
-    # otherwise split on our delimiter
-    split_string = entity_string.split(@delim)
-    entity_type = split_string[0]
-    entity_name = split_string[1]
+      # otherwise split on our delimiter
+      split_string = entity_string.split(@delim)
+      entity_type = split_string[0]
+      entity_name = split_string[1]
 
-    # if a project name is specified, grab it
-    if split_string.count > 2
-      project_name = split_string[2]
+      # if a project name is specified, grab it
+      if split_string.count > 2
+        project_name = split_string[2]
+      end
+
+      # create the hash we'll return
+      entity_hash = {
+        "project_name" => project_name,
+        "type" => entity_type,
+        "name" => entity_name,
+        "details" => { "name" => entity_name }
+      }
+
+      puts "Got entity: #{entity_hash}" if @debug
+      return entity_hash
     end
-
-    # create the hash we'll return
-    entity_hash = {
-      "project_name" => project_name,
-      "type" => entity_type,
-      "name" => entity_name,
-      "details" => { "name" => entity_name }
-    }
-
-    puts "Got entity: #{entity_hash}" if @debug
-
-  entity_hash
   end
 
   # Parse out options from cli

--- a/db/073_update_entities_add_sensitive_details_column.rb
+++ b/db/073_update_entities_add_sensitive_details_column.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  change do
+
+    alter_table :entities do
+      add_column :sensitive_details, String, :default => '[]', :text => true
+    end
+
+  end
+end

--- a/lib/entities/aws_credential.rb
+++ b/lib/entities/aws_credential.rb
@@ -11,9 +11,8 @@ module Intrigue
     end
   
     def validate_entity
-      name.match(/.*\*\*\*$/) &&
-      details["hidden_access_id"] &&
-      details["hidden_secret_key"]
+      sensitive_details["aws_access_key_id"] &&
+      sensitive_details["aws_secret_access_key"]
     end
   
     def scoped?

--- a/lib/entities/aws_credential.rb
+++ b/lib/entities/aws_credential.rb
@@ -1,0 +1,29 @@
+module Intrigue
+  module Entity
+  class AwsCredential < Intrigue::Core::Model::Entity
+  
+    def self.metadata
+      {
+        name: "AwsCredential",
+        description: "AWS Credential",
+        sensitive: true
+      }
+    end
+  
+    def validate_entity
+      name.match(/.*\*\*\*$/) &&
+      details["hidden_access_id"] &&
+      details["hidden_secret_key"]
+    end
+  
+    def scoped?
+      return true if scoped
+      return true if self.allow_list || self.project.allow_list_entity?(self) 
+      return false if self.deny_list || self.project.deny_list_entity?(self)
+    true # otherwise just default to true
+    end
+  
+  end
+  end
+  end
+  

--- a/lib/entity_manager.rb
+++ b/lib/entity_manager.rb
@@ -53,7 +53,7 @@ class EntityManager
   ###
   ### Use this when creating the first entity (without a task)
   ###
-  def self.create_first_entity(project_name,type_string,name,details_hash={})
+  def self.create_first_entity(project_name,type_string,name,details_hash={}, sensitive_details_hash={})
     # get type of entity
     type = resolve_type_from_string(type_string)
 
@@ -73,6 +73,7 @@ class EntityManager
     if entity # already exists, but now it's created by us... let's clean it up
 
       entity.set_details(details_hash.to_h.deep_merge(entity.details.to_h))
+      entity.set_sensitive_details(sensitive_details_hash.to_h.deep_merge(entity.sensitive_details.to_h))
 
       # always scoped
       entity.set_scoped!(true, "first_entity")
@@ -93,6 +94,7 @@ class EntityManager
         project: project,
         type: type,
         details: details_hash,
+        sensitive_details: sensitive_details_hash,
         hidden: false, # first entity should NEVER be hidden - it was intentional
         scoped: true,  # first entity should ALWAYS be in scope - it was intentional
         allow_list: true,
@@ -122,7 +124,7 @@ class EntityManager
   ###
   ### Use this when creating an entity with an associated task result
   ###
-  def self.create_or_merge_entity(task_result_id, type_string, name, details_hash={}, primary_entity=nil)
+  def self.create_or_merge_entity(task_result_id, type_string, name, details_hash={}, primary_entity=nil, sensitive_details_hash={})
     # get type of entity
     type = resolve_type_from_string(type_string)
 
@@ -155,7 +157,7 @@ class EntityManager
     if entity
 
       entity.set_details(details_hash.to_h.deep_merge(entity.details.to_h))
-
+      entity.set_sensitive_details(sensitive_details_hash.to_h.deep_merge(entity.sensitive_details.to_h))
       # if it already exists, it'll have an alias group ID and we'll
       # want to use that to preserve pre-existing relatiohships
       # also... prevents an enrichment loop
@@ -184,6 +186,7 @@ class EntityManager
             type: type.to_s,
             project_id: project.id,
             details: details_hash,
+            sensitive_details: sensitive_details_hash,
             alias_group_id: alias_group_id
           })
 

--- a/lib/system/bootstrap.rb
+++ b/lib/system/bootstrap.rb
@@ -66,7 +66,7 @@ module Bootstrap
       end
 
       # parse up the seeds
-      parsed_seeds = p["seeds"].map{|s| _parse_entity s["entity"] }
+      parsed_seeds = p["seeds"].map{|s| _parse_entity_hash s }
 
       # handle no-seed cases
       next unless parsed_seeds.count > 0
@@ -115,7 +115,7 @@ module Bootstrap
   end
 
 
-  private
+  
 
   # parse out entity from the cli
   def _parse_entity(entity_string)
@@ -137,6 +137,23 @@ module Bootstrap
   entity_hash
   end
 
+  def _parse_entity_hash(entity_hash)
+    if entity_hash.class != Hash
+      puts "Error while parsing entity hash: Invalid type"
+      return nil
+    end
+
+    parsed_entity_hash = Intrigue::Core::System::Bootstrap::_parse_entity(entity_hash["entity"]) # have to namespace for core-cli to work
+ 
+    # merge details from bootstrap seed entity
+    if entity_hash.key?("details")
+      parsed_entity_hash["details"] = parsed_entity_hash["details"].merge(entity_hash["details"])
+    end
+
+  parsed_entity_hash
+  end
+
+  private
   # Parse out options from cli
   def _parse_options(option_string)
 

--- a/lib/system/bootstrap.rb
+++ b/lib/system/bootstrap.rb
@@ -92,7 +92,7 @@ module Bootstrap
 
               # Create & scope the entity
               created_entity = Intrigue::EntityManager.create_first_entity(
-                project_name, entity["type"], entity["details"]["name"], entity["details"])
+                project_name, entity["type"], entity["details"]["name"], entity["details"], entity["sensitive_details"])
 
               # just in case we tried to create an invalid entity, skip
               next unless created_entity
@@ -131,7 +131,8 @@ module Bootstrap
     entity_hash = {
       "type" => entity_type,
       "name" => entity_name,
-      "details" => { "name" => entity_name, "whitelist" => true }
+      "details" => { "name" => entity_name, "whitelist" => true },
+      "sensitive_details" => {}
     }
 
   entity_hash
@@ -148,6 +149,10 @@ module Bootstrap
     # merge details from bootstrap seed entity
     if entity_hash.key?("details")
       parsed_entity_hash["details"] = parsed_entity_hash["details"].merge(entity_hash["details"])
+    end
+
+    if entity_hash.key?("sensitive_details")
+      parsed_entity_hash["sensitive_details"] = parsed_entity_hash["sensitive_details"].merge(entity_hash["sensitive_details"])
     end
 
   parsed_entity_hash

--- a/lib/tasks/aws_ec2_gather_instances.rb
+++ b/lib/tasks/aws_ec2_gather_instances.rb
@@ -10,7 +10,7 @@ module Intrigue
           references: [],
           type: 'discovery',
           passive: true,
-          allowed_types: ['String'],
+          allowed_types: ['String', 'AwsCredential'],
           example_entities: [{ 'type' => 'String', 'details' => { 'name' => '__IGNORE__', 'default' => '__IGNORE__' } }],
           allowed_options: [
             { name: 'region', regex: 'alpha_numeric', default: 'us-east-1' }
@@ -24,8 +24,8 @@ module Intrigue
         super
 
         # Get the AWS Credentials
-        aws_access_key = _get_task_config('aws_access_key_id')
-        aws_secret_key = _get_task_config('aws_secret_access_key')
+        aws_access_key, aws_secret_key = get_aws_keys_from_entity_type(_get_entity_type_string)
+        return unless aws_access_key && aws_secret_key
         aws_region = _get_option 'region'
 
         ec2 = Aws::EC2::Resource.new(region: aws_region, access_key_id: aws_access_key, secret_access_key: aws_secret_key)

--- a/lib/tasks/aws_iam_gather_accounts.rb
+++ b/lib/tasks/aws_iam_gather_accounts.rb
@@ -10,7 +10,7 @@ module Intrigue
           references: [],
           type: 'discovery',
           passive: true,
-          allowed_types: ['String'],
+          allowed_types: ['String', 'AwsCredential'],
           example_entities: [{ 'type' => 'String', 'details' => { 'name' => '__IGNORE__', 'default' => '__IGNORE__' } }],
           allowed_options: [],
           created_types: ['AwsIamAccount']
@@ -21,8 +21,9 @@ module Intrigue
       def run
         super
 
-        aws_access_key = _get_task_config('aws_access_key_id')
-        aws_secret_key = _get_task_config('aws_secret_access_key')
+        # Get the AWS Credentials
+        aws_access_key, aws_secret_key = get_aws_keys_from_entity_type(_get_entity_type_string)
+        return unless aws_access_key && aws_secret_key
 
         # IAM is global so region is not needed
         iam = Aws::IAM::Client.new({ region: 'us-east-1', access_key_id: aws_access_key, secret_access_key: aws_secret_key })

--- a/lib/tasks/aws_route53.rb
+++ b/lib/tasks/aws_route53.rb
@@ -10,7 +10,7 @@ module Intrigue
           references: ['https://docs.aws.amazon.com/Route53/latest/APIReference/Welcome.html'],
           type: 'discovery',
           passive: true,
-          allowed_types: ['String'],
+          allowed_types: ['String', 'AwsCredential'],
           example_entities: [{ 'type' => 'String', 'details' => { 'name' => '__IGNORE__', 'default' => '__IGNORE__' } }],
           example_entity_placeholder: false,
           allowed_options: [
@@ -24,8 +24,9 @@ module Intrigue
       def run
         super
 
-        aws_access_key = _get_task_config('aws_access_key_id')
-        aws_secret_key = _get_task_config('aws_secret_access_key')
+        # Get the AWS Credentials
+        aws_access_key, aws_secret_key = get_aws_keys_from_entity_type(_get_entity_type_string)
+        return unless aws_access_key && aws_secret_key
         hosted_zone_id = _get_option 'Hosted Zone ID'
 
         # route53 is global; region does not matter. set to us-east-1 to satisfy SDK.

--- a/lib/tasks/aws_s3_gather_buckets.rb
+++ b/lib/tasks/aws_s3_gather_buckets.rb
@@ -10,7 +10,7 @@ module Intrigue
           references: [],
           type: 'discovery',
           passive: true,
-          allowed_types: ['String'],
+          allowed_types: ['String', 'AwsCredential'],
           example_entities: [{ 'type' => 'String', 'details' => { 'name' => '__IGNORE__', 'default' => '__IGNORE__' } }],
           allowed_options: [],
           created_types: ['AwsS3Bucket']
@@ -22,9 +22,13 @@ module Intrigue
         super
 
         # Get the AWS Credentials
-        aws_access_key = _get_task_config('aws_access_key_id')
-        aws_secret_key = _get_task_config('aws_secret_access_key')
-
+        if _get_entity_type_string == "AwsCredential"
+          aws_access_key = _get_entity_sensitive_detail 'aws_access_key_id'
+          aws_secret_key = _get_entity_sensitive_detail 'aws_secret_access_key'
+        else
+          aws_access_key = _get_task_config('aws_access_key_id')
+          aws_secret_key = _get_task_config('aws_secret_access_key')
+        end
         # when querying account for buckets; region doesn't make a difference so we use us-east-1 by default
         s3 = Aws::S3::Resource.new(region: 'us-east-1', access_key_id: aws_access_key, secret_access_key: aws_secret_key)
 

--- a/lib/tasks/aws_s3_gather_buckets.rb
+++ b/lib/tasks/aws_s3_gather_buckets.rb
@@ -44,11 +44,19 @@ module Intrigue
         _log_good "Retrieved #{bucket_names.size} buckets."
 
         bucket_names.each do |name|
-          _create_entity 'AwsS3Bucket', {
+          en = _create_entity 'AwsS3Bucket', {
             'name' => name, # use the new virtual host path since path style will be deprecated,
             'bucket_name' => name,
-            'bucket_uri' => "#{name}.s3.amazonaws.com"
+            'bucket_uri' => "#{name}.s3.amazonaws.com",
           }
+
+          # record how we retrieved the s3 bucket
+          if _get_entity_type_string == 'AwsCredential'
+            en.set_detail("source", "aws_credential")
+            en.set_sensitive_detail("source_entity_id", @entity.id)
+          elsif _get_entity_type_string == 'String'
+            en.set_detail("source", "configuration")
+          end 
         end
       end
     end

--- a/lib/tasks/aws_s3_gather_buckets.rb
+++ b/lib/tasks/aws_s3_gather_buckets.rb
@@ -22,14 +22,11 @@ module Intrigue
         super
 
         # Get the AWS Credentials
-        if _get_entity_type_string == "AwsCredential"
-          aws_access_key = _get_entity_sensitive_detail 'aws_access_key_id'
-          aws_secret_key = _get_entity_sensitive_detail 'aws_secret_access_key'
-        else
-          aws_access_key = _get_task_config('aws_access_key_id')
-          aws_secret_key = _get_task_config('aws_secret_access_key')
-        end
+        aws_access_key, aws_secret_key = get_aws_keys_from_entity_type(_get_entity_type_string)
+        return unless aws_access_key && aws_secret_key
+        
         # when querying account for buckets; region doesn't make a difference so we use us-east-1 by default
+        _log "Getting S3 buckets..."
         s3 = Aws::S3::Resource.new(region: 'us-east-1', access_key_id: aws_access_key, secret_access_key: aws_secret_key)
 
         begin

--- a/lib/tasks/helpers/aws.rb
+++ b/lib/tasks/helpers/aws.rb
@@ -68,6 +68,29 @@ module Intrigue
         bucket_name
       end
 
+      def get_aws_keys_from_entity_type(entity_type)
+        if entity_type == "AwsCredential"
+          aws_access_key = _get_entity_sensitive_detail 'aws_access_key_id'
+          aws_secret_key = _get_entity_sensitive_detail 'aws_secret_access_key'
+        elsif entity_type == "String"
+          aws_access_key = _get_task_config('aws_access_key_id')
+          aws_secret_key = _get_task_config('aws_secret_access_key')
+        else
+          aws_access_key = nil
+          aws_secret_key = nil
+        end
+
+        # if empty string return nil
+        if aws_access_key == ""
+          aws_access_key = nil
+        end
+        if aws_secret_key == ""
+          aws_secret_key = nil
+        end
+
+        return aws_access_key, aws_secret_key
+      end
+
     end
   end
 end

--- a/lib/tasks/helpers/aws.rb
+++ b/lib/tasks/helpers/aws.rb
@@ -91,6 +91,7 @@ module Intrigue
         end
 
         return aws_access_key, aws_secret_key
+      end
 
       def extract_bucket_name_from_string(str)
         virtual_style_regex = /(?:https:\/\/)?([a-z0-9\-\.]+)\.s3(?:-|.+)?\.amazonaws\.com/i

--- a/lib/tasks/helpers/generic.rb
+++ b/lib/tasks/helpers/generic.rb
@@ -145,6 +145,14 @@ module Generic
     @entity.set_detail(detail_name, detail_value)
   end
 
+  def _get_entity_sensitive_detail(detail_name)
+    @entity.get_sensitive_detail(detail_name)
+  end
+
+  def _set_entity_sensitive_detail(detail_name, detail_value)
+    @entity.set_sensitive_detail(detail_name, detail_value)
+  end
+
   def _get_and_set_entity_details(hash)
     @entity.get_and_set_details hash
   end

--- a/lib/tasks/helpers/generic.rb
+++ b/lib/tasks/helpers/generic.rb
@@ -145,10 +145,6 @@ module Generic
     @entity.set_detail(detail_name, detail_value)
   end
 
-  def _get_entity_details
-    @entity.get_details
-  end
-
   def _get_and_set_entity_details(hash)
     @entity.get_and_set_details hash
   end


### PR DESCRIPTION
This PR enables support for cloudcredentials as entities, which have a `sensitive_details` field. This field is not shown anywhere nor exported. It is simply used to store sensitive details as part of an entity. 

In addition to that, there is a `_get_entity_sensitive_detail` helper function designed to access these details.