### PR TITLE
COR-40: fixing issues on threat tasks

### DIFF
--- a/config/config.json.default
+++ b/config/config.json.default
@@ -363,7 +363,7 @@
     },
     "ipqs_api_key": {
       "value": "",
-      "uri": "https://www.ipqualityscore.com/documentation/fraud-prevention-api-use-cases,
+      "uri": "https://www.ipqualityscore.com/documentation/fraud-prevention-api-use-cases",
       "editable": "true",
       "comment": ""
     },

--- a/config/config.json.default
+++ b/config/config.json.default
@@ -361,6 +361,12 @@
       "editable": "true",
       "comment": ""
     },
+    "ipqs_api_key": {
+      "value": "",
+      "uri": "https://www.ipqualityscore.com/documentation/fraud-prevention-api-use-cases,
+      "editable": "true",
+      "comment": ""
+    },
     "mailbox_layer_apikey": {
       "value": "",
       "uri": "https://mailboxlayer.com/dashboard",

--- a/lib/tasks/threat/search_emerging_threats.rb
+++ b/lib/tasks/threat/search_emerging_threats.rb
@@ -1,6 +1,6 @@
 module Intrigue
 module Task
-class SearchBadIps < BaseTask
+class SearchEmergingThreats < BaseTask
 
   def self.metadata
     {
@@ -33,7 +33,7 @@ class SearchBadIps < BaseTask
       return
     end
 
-    # Create an issue if an IP found in the Talos IP Blacklist
+    # Create an issue if an IP found in the Emerging Threats Blacklist
     if data.include? entity_name
        source = "emergingthreats.net"
        description = "emerginthreats.net is a well reputed blacklist "

--- a/lib/tasks/threat/search_ibm_x_force.rb
+++ b/lib/tasks/threat/search_ibm_x_force.rb
@@ -56,7 +56,7 @@ class SearchIBMXForce < BaseTask
 
     if json["error"] == "Not authorized."
 
-      _log_error "Not authorized. Please check your credentials."
+      _log_error "Not authorized. Please check your API credentials."
 
       return
 

--- a/lib/tasks/threat/search_ibm_x_force.rb
+++ b/lib/tasks/threat/search_ibm_x_force.rb
@@ -37,7 +37,7 @@ class SearchIBMXForce < BaseTask
 
     if entity_type == "IpAddress"
       #search Ip for reputation and related information
-      search_ip_reputation entity_name
+      search_ip_reputation(entity_name, headers)
     else
       _log_error "Unsupported entity type"
     end
@@ -45,7 +45,7 @@ class SearchIBMXForce < BaseTask
   end #end
 
   # Get IP Reputation
-  def search_ip_reputation(entity_name)
+  def search_ip_reputation(entity_name, headers)
 
     # Set the URL for ip data
     url = "https://api.xforce.ibmcloud.com:443/ipr/history/#{entity_name}"
@@ -53,6 +53,14 @@ class SearchIBMXForce < BaseTask
     # make the request
     response = http_get_body(url,nil,headers)
     json = JSON.parse(response)
+
+    if json["error"] == "Not authorized."
+
+      _log_error "Not authorized. Please check your credentials."
+
+      return
+
+    end
 
     json["history"].each do |result|
 


### PR DESCRIPTION
- Added `IpQualityScore` API key as a configurable option for tasks
- Fixed the class name on the `SearchEmergingThreats` threat task, which was needed for Core to see the task properly
- On the `IBM X Force` task the header input was not passed to the function properly (it contains the authentication info), as well as there was no auth failure check in place, which is now added.

Jira ticket: https://intriguesecurity.atlassian.net/browse/COR-40