### PR TITLE
Fix Vulnerability Checks not being fired off in enrich/uri

### DIFF
--- a/lib/tasks/helpers/cloud_providers.rb
+++ b/lib/tasks/helpers/cloud_providers.rb
@@ -20,11 +20,8 @@ module CloudProviders
   private 
 
   def _cloud_classifier_lookup(ip_address)
-    cloudclassifier_api_key = _get_task_config "cloudclassifier_api_key"
-    unless cloudclassifier_api_key
-      _log_error "Unable to check, verify you've entered a valid Intrigue.io API key!"
-      return nil
-    end
+    cloudclassifier_api_key = _retrieve_cloud_classifier_key
+    return nil if cloudclassifier_api_key.nil?
 
     begin 
       api_url = "https://cloudclassifier.intrigue.io/search/ip/#{ip_address}?key=#{cloudclassifier_api_key}"
@@ -44,6 +41,12 @@ module CloudProviders
     end
   
   nil
+  end
+
+  def _retrieve_cloud_classifier_key
+    _get_task_config 'cloudclassifier_api_key'
+  rescue MissingTaskConfigurationError
+    _log_error 'Cloud Classifier API missing in the task config; skipping cloud classification.'
   end
 
   def _get_cloud_status_ip_address(ip_address)


### PR DESCRIPTION
Hi team,

Please find in this PR the fix for the `enrich/uri` task not kicking off vuln checks in the case where the Cloud Classifier API Key is missing.

### Background

`enrich/uri` calls the `determine_cloud_status()` method passing in the entity on Line 424:
```
 cloud_providers = determine_cloud_status(@entity)
```

`determine_cloud_status()` method itself is a helper method belonging to `cloud_providers.rb` which in turn fires off three methods:

```
    out = _get_cloud_status_dns_record(entity.name) if entity.kind_of? Intrigue::Entity::DnsRecord 
    out = _get_cloud_status_ip_address(entity.name) if entity.kind_of? Intrigue::Entity::IpAddress 
    out = _get_cloud_status_uri(entity.name) if entity.kind_of? Intrigue::Entity::Uri
```

Each of the `_get_cloud_status()` methods in turn calls the `_cloud_classifier_lookup()` method which is responsible for hitting the Cloud Classifier API and returning the results.

The `_cloud_classifier_lookup()` itself calls `_get_task_config()` to retrieve the Cloud Classifier API Key. The issue here is whenever `_get_task_config()` is called with a value that doesn't have an API key, an exception will be thrown:

```
[E] Missing task configuration, please check configuration for this task: Please enter your cloudclassifier_api_key setting in 'Configure -> Task Configuration'
```
 
This exception is not gracefully handled by `_cloud_classifer_lookup()` and as such the exception is thrown thus abruptly halting the `enrich/uri` task.

The logic responsible for kicking off the vulnerability checks is a few lines below `determine_cloud_status()` and as such the vulnerability checks are never created:

```
    # Now that we have our core details, check cloud statusi
    cloud_providers = determine_cloud_status(@entity)
    _set_entity_detail("cloud_providers", cloud_providers.uniq.sort)
    _set_entity_detail("cloud_hosted",  !cloud_providers.empty?)

    ###
    ### Create issues for any vulns that are version-only inference
    ###
    fingerprint_to_inference_issues(ident_fingerprint)

    ###
    ### Kick off vuln checks if enabled for the project
    ###
    all_checks = []
    if @project.vulnerability_checks_enabled
      vuln_checks = run_vuln_checks_from_fingerprint(ident_fingerprint, @entity)
      _set_entity_detail("vuln_checks", vuln_checks)
    end
```

### Fix

A new private method was implemented to `cloud_providers.rb` which gracefully handles the exception:

```
  def _retrieve_cloud_classifier_key
    _get_task_config 'cloudclassifier_api_key'
  rescue MissingTaskConfigurationError
    _log_error 'Cloud Classifier API missing in the task config; skipping cloud classification.'
  end
```

Thanks,
Maxim
