### PR TITLE
Fix missing gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,12 +10,6 @@ GIT
       logging (~> 2.0)
       test-unit (~> 3.1, >= 3.1.5)
 
-GIT
-  remote: https://github.com/intrigueio/cloudflare.git
-  revision: be12151e164f2e636560f7947cdbc601ab003ce6
-  specs:
-    cloudflare (4.2.0)
-      async-rest (~> 0.10.0)
 
 GIT
   remote: https://github.com/intrigueio/ip_ranger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,12 +18,6 @@ GIT
       async-rest (~> 0.10.0)
 
 GIT
-  remote: https://github.com/intrigueio/dnsbl-client.git
-  revision: d88bb5eae3dfd03c418f67ae5767234a862a92b8
-  specs:
-    dnsbl-client (1.0.4)
-
-GIT
   remote: https://github.com/intrigueio/ip_ranger
   revision: e1e4080070cf699cd0b80c5c8d6d5dddfc19d4b8
   specs:


### PR DESCRIPTION
This PR fixes the missing Gems due to the forked Intrigue repositories being deleted.

The following was modified:
- `Dnsbl` was removed as its not in use anymore
- `Spidr` repo was reforked as it appears to be in use at https://github.com/intrigueio/intrigue-core/blob/develop/lib/tasks/uri_spider.rb#L99 
- `Rex-SSLScan` was reforked as it appears to be in use at https://github.com/intrigueio/intrigue-core/blob/develop/lib/tasks/enrich/uri.rb#L445
- `NeutrinoAPI-Ruby` was reforked as it appears to be in use at https://github.com/intrigueio/intrigue-core/blob/develop/lib/tasks/search_neutrino_api.rb#L48
- `ip_ranger` was reforked as it appears to be in use at https://github.com/intrigueio/intrigue-core/blob/develop/lib/tasks/helpers/whois.rb#L170
- `cloudflare` was reforked as it appears to be in use at https://github.com/intrigueio/intrigue-core/blob/develop/lib/tasks/cloudflare_zones.rb#L38

The following gems have been 'modified' as I had to remove the cached commit id (due to the forked repo not existing anymore) from the `Gemfile.lock` meaning that it re-installed the latest version and we should probably verify the tasks that use these gems are not affected:

- chrome_remote
- cloudflare

The rest of the Gems in the Gemfile.lock had the same commit id meaning that they were not affected.

Truth be told this could've worked by pointing the location of the gem to the Github location since any modifications made to the forked gem were deleted anyways when the repositories were deleted.

Best regards,
Maxim

