### PR TITLE
Add 

### DIFF
--- a/lib/tasks/aws_s3_bruteforce_objects.rb
+++ b/lib/tasks/aws_s3_bruteforce_objects.rb
@@ -39,6 +39,7 @@ module Intrigue
         readable_objects = filter_readable_objects(s3_client, bucket_name, objects_list)
         return if readable_objects.empty?
 
+        add_objects_to_entity(@entity, readable_objects)
         create_issue(bucket_name, readable_objects)
       end
 

--- a/lib/tasks/aws_s3_bruteforce_objects.rb
+++ b/lib/tasks/aws_s3_bruteforce_objects.rb
@@ -39,7 +39,7 @@ module Intrigue
         readable_objects = filter_readable_objects(s3_client, bucket_name, objects_list)
         return if readable_objects.empty?
 
-        add_objects_to_entity(@entity, readable_objects)
+        add_objects_to_s3_entity(@entity, readable_objects)
         create_issue(bucket_name, readable_objects)
       end
 

--- a/lib/tasks/aws_s3_find_listable_objects.rb
+++ b/lib/tasks/aws_s3_find_listable_objects.rb
@@ -42,7 +42,7 @@ module Intrigue
           _log "No listable objects found via unauthenticated method"
         else
           _log_good "Found #{bucket_objects.size} listable object(s)."
-          add_objects_to_entity(@entity, bucket_objects)
+          add_objects_to_s3_entity(@entity, bucket_objects)
           create_issue(bucket_name, bucket_objects)
         end
 
@@ -56,7 +56,7 @@ module Intrigue
               _log "No listable objects found via unauthenticated method"
             else
               _log_good "Found #{bucket_objects.size} listable object(s)."
-              add_objects_to_entity(@entity, bucket_objects)
+              add_objects_to_s3_entity(@entity, bucket_objects)
               create_issue(bucket_name, bucket_objects)
             end
           end

--- a/lib/tasks/aws_s3_find_listable_objects.rb
+++ b/lib/tasks/aws_s3_find_listable_objects.rb
@@ -42,6 +42,7 @@ module Intrigue
           _log "No listable objects found via unauthenticated method"
         else
           _log_good "Found #{bucket_objects.size} listable object(s)."
+          add_objects_to_entity(@entity, bucket_objects)
           create_issue(bucket_name, bucket_objects)
         end
 
@@ -55,6 +56,7 @@ module Intrigue
               _log "No listable objects found via unauthenticated method"
             else
               _log_good "Found #{bucket_objects.size} listable object(s)."
+              add_objects_to_entity(@entity, bucket_objects)
               create_issue(bucket_name, bucket_objects)
             end
           end

--- a/lib/tasks/enrich/aws_s3_bucket.rb
+++ b/lib/tasks/enrich/aws_s3_bucket.rb
@@ -26,37 +26,27 @@ module Intrigue
           # TODO bug fix: when entity is created from task; name detail is not stored
           bucket_name = _get_entity_detail('name') || _get_entity_detail('bucket_name')
           
-          # check if the bucket actually exists. If not, this will hide the entity.
-          return unless bucket_exists?(bucket_name)
-
-          # check if bucket is owned by aws keys in configuration
-          region = _get_entity_detail('region')
-          s3_client = initialize_s3_client(region, bucket_name)
-          bucket_belongs_to_api_key?(s3_client, bucket_name) if s3_client
-        end
- 
-        ## confirm the bucket exists by extracting the region from the response headers
-        def bucket_exists?(bucket_name)
-          exists = true
-          region = http_request(:get, "https://#{bucket_name}.s3.amazonaws.com").headers['x-amz-bucket-region']
-
-          if region.nil?
-            @entity.hidden = true # bucket is invalid; hide the entity
-            _log_error 'Unable to determine region of bucket. Bucket most likely does not exist.'
-            exists = false
+          if region = bucket_exists?(bucket_name)
+            _set_entity_detail('bucket_name', bucket_name)
+            _set_entity_detail('found_objects', []) unless _get_entity_detail('found_objects')
+            _set_entity_detail('region', region)
+            check_bucket_belongs_to_key(region, bucket_name)
           else
-            _log "Bucket lives in the #{region} region."
-            _set_entity_detail 'region', region
-            _set_entity_detail 'bucket_name', bucket_name 
+            _log_error 'Unable to determine region of bucket. Bucket most likely does not exist.'
+            @entity.hidden = true
+            @entity.save_changes
           end
-
-          exists
         end
 
+        def bucket_exists?(bucket_name)
+          region = http_request(:get, "https://#{bucket_name}.s3.amazonaws.com").headers['x-amz-bucket-region']
+          region
+        end
 
         ## check if the AWS keys provided by the user own the bucket -> theres a better way of doing this
-        def bucket_belongs_to_api_key?(client, bucket)
-          result = false
+        def check_bucket_belongs_to_key(region, bucket_name)
+          s3_client = initialize_s3_client(region, bucket_name)
+          return if s3_client.nil?
 
           begin
             result = client.list_buckets['buckets'].collect(&:name).include? bucket
@@ -64,10 +54,10 @@ module Intrigue
             _log 'AWS Keys do not have permission to list the buckets belonging to the account; defaulting to false.'
           end
 
-          if result
-            _log 'Bucket belongs to API Key.' 
-            _set_entity_detail 'source', 'configuration'
-          end
+          return unless result
+
+          _log 'Bucket belongs to API Key.' 
+          _set_entity_detail 'source', 'configuration'
         end
 
       end

--- a/lib/tasks/helpers/aws.rb
+++ b/lib/tasks/helpers/aws.rb
@@ -39,6 +39,15 @@ module Intrigue
         client
       end
 
+      def add_objects_to_entity(entity, new_objects)
+        objects = entity.get_detail('found_objects')
+        uniq_objects = new_objects - objects
+        return if uniq_objects.empty?
+
+        (objects << uniq_objects).flatten!
+        entity.set_detail('found_objects', objects)
+      end
+
       # extracts the bucket_name from a URL
       # there can be different types of naming schemes - virtual hosted & path_style
       def extract_bucket_name_from_uri(bucket_url)
@@ -99,7 +108,6 @@ module Intrigue
         concat_regex = Regexp.union(virtual_style_regex, path_style_regex)
 
         str.scan(concat_regex).flatten.compact.last
-
       end
 
     end

--- a/lib/tasks/helpers/aws.rb
+++ b/lib/tasks/helpers/aws.rb
@@ -39,7 +39,7 @@ module Intrigue
         client
       end
 
-      def add_objects_to_entity(entity, new_objects)
+      def add_objects_to_s3_entity(entity, new_objects)
         objects = entity.get_detail('found_objects')
         uniq_objects = new_objects - objects
         return if uniq_objects.empty?


### PR DESCRIPTION
Hi team,

Please find attached in this PR multiple enhancements for the `Aws S3 Bucket` tasks.

- The `add_objects_to_s3_entity` helper method has been created which adds the objects which were found by various tasks to the `AwsS3Bucket` entity details. 

   Truth be told this could be done by creating an entity of the existing entity (as the details would be merged) however that seems to be a bit excessive due to the enrichment task running additional checks (such as verifying that the bucket exists, etc.) However if this is the agreed-upon way to go about this, we can modify so the enrichment task will only perform those respective checks if the entity detail is missing (aka new entity).

- The `AwsS3Bucket`enrichment task has been refactored and updated to support the `found_objects` entity detail.

Best regards,
Maxim