### PR TITLE
Github Tasks Enhancements

### DIFF
--- a/lib/entities/github_account.rb
+++ b/lib/entities/github_account.rb
@@ -1,33 +1,31 @@
 module Intrigue
-module Entity
-class GithubAccount < Intrigue::Core::Model::Entity
+  module Entity
+    class GithubAccount < Intrigue::Core::Model::Entity
+      def self.metadata
+        {
+          name: 'GithubAccount',
+          description: 'A Github Account',
+          user_creatable: true,
+          example: 'https://github.com/intrigueio'
+        }
+      end
 
-  def self.metadata
-    {
-      name: "GithubAccount",
-      description: "A Github Account",
-      user_creatable: true,
-      example: "intrigueio"
-    }
+      def validate_entity
+        name.match /^https:\/\/github.com\/[\w\-]{1,39}$/
+      end
+
+      def enrichment_tasks
+        # to enrich github accounts, use enrich/github_account and prepend to array below
+        ['gather_github_repositories']
+      end
+
+      def scoped?
+        return scoped unless scoped.nil?
+        return true if allow_list || project.allow_list_entity?(self)
+        return false if deny_list || project.deny_list_entity?(self)
+
+        true
+      end
+    end
   end
-
-  def validate_entity
-    name.match /^[\d\w]+/
-  end
-
-  def enrichment_tasks
-     # to enrich github accounts, use enrich/github_account and prepend to array below
-    ['gather_github_repositories']
-  end
-
-  def scoped?
-    return scoped unless scoped.nil?
-    return true if self.allow_list || self.project.allow_list_entity?(self)
-    return false if self.deny_list || self.project.deny_list_entity?(self)
-
-  true
-  end
-
-end
-end
 end

--- a/lib/entities/github_repository.rb
+++ b/lib/entities/github_repository.rb
@@ -11,8 +11,13 @@ class GithubRepository < Intrigue::Core::Model::Entity
     }
   end
 
+  def enrichment_tasks
+    ['enrich/github_repository']
+  end
+
+
   def validate_entity
-    name.match /^https:\/\/github.com\/[\d\w\-]{1,39}+\/[\d\w\-]{1,100}+/
+    name.match /^https:\/\/github.com\/[\w\-]{1,39}+\/[\w\-]{1,100}+/
   end
 
   def scoped?

--- a/lib/tasks/enrich/github_repository.rb
+++ b/lib/tasks/enrich/github_repository.rb
@@ -26,8 +26,7 @@ module Intrigue
         ## Default method, subclasses must override this
 
         def run
-          repo_name = _get_entity_detail('name') 
-          repo_name = extract_full_repo_name(repo_name) if repo_name =~ /https:\/\/github\.com/i
+          repo_name = extract_full_repo_name(_get_entity_name)
 
           _set_entity_detail('owner', repo_name.split('/').first)
           _set_entity_detail('repository_name', repo_name.split('/')[1])
@@ -39,10 +38,6 @@ module Intrigue
           # if non 404 we'll just assume its private
           r = http_request(:get, "https://api.github.com/repos/#{repo_full_name}")
           r.code == '200'
-        end
-
-        def extract_full_repo_name(repo)
-          repo.scan(/https:\/\/github\.com\/([\w|\-]+\/[\w|\-]+)/i).flatten.first
         end
 
       end

--- a/lib/tasks/enrich/github_repository.rb
+++ b/lib/tasks/enrich/github_repository.rb
@@ -1,0 +1,51 @@
+module Intrigue
+  module Task
+    module Enrich
+      class GithubRepository < Intrigue::Task::BaseTask
+        def self.metadata
+          {
+            name: 'enrich/github_repository',
+            pretty_name: 'Github Repository Enrichment',
+            authors: ['maxim'],
+            description: 'Ensures the entity is marked enriched. Used when there is no specific enrichment task!',
+            references: [],
+            type: 'enrichment',
+            passive: true,
+            allowed_types: ['GithubRepository'],
+            example_entities: [
+              { 'type' => 'GithubRepository',
+                'details' => {
+                  'name' => 'https://github.com/intrigueio/intrigue-core'
+                } }
+            ],
+            allowed_options: [],
+            created_types: []
+          }
+        end
+
+        ## Default method, subclasses must override this
+
+        def run
+          repo_name = _get_entity_detail('name') 
+          repo_name = extract_full_repo_name(repo_name) if repo_name =~ /https:\/\/github\.com/i
+
+          _set_entity_detail('owner', repo_name.split('/').first)
+          _set_entity_detail('repository_name', repo_name.split('/')[1])
+          _set_entity_detail('repository_uri', "https://github.com/#{repo_name}")
+          _set_entity_detail('repository_public', repo_public?(repo_name))
+        end
+
+        def repo_public?(repo_full_name) 
+          # if non 404 we'll just assume its private
+          r = http_request(:get, "https://api.github.com/repos/#{repo_full_name}")
+          r.code == '200'
+        end
+
+        def extract_full_repo_name(repo)
+          repo.scan(/https:\/\/github\.com\/([\w|\-]+\/[\w|\-]+)/i).flatten.first
+        end
+
+      end
+    end
+  end
+end

--- a/lib/tasks/gather_github_repositories.rb
+++ b/lib/tasks/gather_github_repositories.rb
@@ -64,9 +64,9 @@ module Intrigue
           end
 
           break
-        rescue Octokit::AbuseDetected => e
-          _log_error "#{e}\nRate limiting hit on attempt #{i}. Retrying."
-          sleep 300 # sleep 5 mins to reset 
+        rescue Octokit::AbuseDetected, Octokit::Forbidden
+          _log_error "Rate limiting hit on attempt #{i}; Retrying in 5 minutes."
+          sleep 300
           next
         rescue Octokit::TooManyRequests
           # exhausted the max amount of requests per hour/ just return to not lag other tasks

--- a/lib/tasks/helpers/github.rb
+++ b/lib/tasks/helpers/github.rb
@@ -31,9 +31,14 @@ module Intrigue
 
       # called in two tasks - thus warranting it a helper
       def create_github_repo_entity(repo_full_name)
+        repo_full_name = "https://github.com/#{repo_full_name}" unless repo_full_name.include? 'https://github.com'
         _create_entity 'GithubRepository', {
-          'name' => "https://github.com/#{repo_full_name}",
+          'name' => repo_full_name
         }
+      end
+
+      def extract_full_repo_name(repo)
+        repo.scan(/https:\/\/github\.com\/([\w|\-]+\/[\w|\-]+)/i).flatten.first
       end
 
       ### Single threaded version

--- a/lib/tasks/helpers/github.rb
+++ b/lib/tasks/helpers/github.rb
@@ -33,9 +33,6 @@ module Intrigue
       def create_github_repo_entity(repo_full_name)
         _create_entity 'GithubRepository', {
           'name' => "https://github.com/#{repo_full_name}",
-          'repository_name' => repo_full_name,
-          'owner' => repo_full_name.split('/').first,
-          'repository_uri' => "https://github.com/#{repo_full_name}"
         }
       end
 

--- a/lib/tasks/helpers/github.rb
+++ b/lib/tasks/helpers/github.rb
@@ -34,7 +34,8 @@ module Intrigue
         _create_entity 'GithubRepository', {
           'name' => "https://github.com/#{repo_full_name}",
           'repository_name' => repo_full_name,
-          'owner' => repo_full_name.split('/').first
+          'owner' => repo_full_name.split('/').first,
+          'repository_uri' => "https://github.com/#{repo_full_name}"
         }
       end
 

--- a/lib/tasks/search_github_code.rb
+++ b/lib/tasks/search_github_code.rb
@@ -73,8 +73,8 @@ module Intrigue
 
           # we're complete, no need to retry
           break
-        rescue Octokit::AbuseDetected => e
-          _log_error "#{e}\nRate limiting hit on attempt #{i}; Retrying."
+        rescue Octokit::AbuseDetected, Octokit::Forbidden
+          _log_error "Rate limiting hit on attempt #{i}; Retrying in 5 minutes."
           sleep 300
           next
         rescue Octokit::TooManyRequests

--- a/lib/tasks/search_github_code.rb
+++ b/lib/tasks/search_github_code.rb
@@ -63,7 +63,7 @@ module Intrigue
           while next_url
             sleep 10
             _log "Getting: #{next_url}"
-            results << client.get(next_url)
+            results << client.get(next_url)['items']
 
             # get the next url
             break unless client.last_response.rels[:next]
@@ -87,15 +87,11 @@ module Intrigue
       end
 
       def parse_results(repositories)
-        repositories = repositories.flatten.compact
+        repositories.flatten!.compact!
         _log 'Unable to find any repositories which contain the provided keyword.' if repositories.empty?
         return if repositories.empty?
 
-        # reject all results that don't contain repository key (API adds some duplicate results in a diff format)
-        repos = repositories.reject { |r| r['repository'].nil? }
-        # there will be duplicates however due to different attributes they will not be uniq'd
-        # to help combat this just extract the full repo_name and uniq (because thats the only information needed)
-        repos.map { |repo| repo['repository']['full_name'] }.uniq
+        repositories.map { |repo| repo['repository']['full_name'] }.uniq
       end
 
       def retrieve_gh_client


### PR DESCRIPTION
Hi team,

Please find attached in this PR a few additional tweaks to enhance the Github Tasks:

- `search_github_code` task bug fix
   The `search_github_code` task was originally only taking results from the first response. This was due not retrieving the items from the additional Sawyer response objects. 

- Additional exception handling
   While testing the `search_github_code` task with a unique keyword that would return an enormous amount of results, an exception was thrown that was not being handled. As such, this exception is now handled by all tasks which use the Github API Client.

- Github Repository Enrichment Task
   A new enrichment task was written for the `GithubRepository` entity. This enrichment task verifies whether the repository is public, and sets a few additional details. Originally, a helper method was being used to set the `GithubRepository` entity details however I felt that was a bad pattern to follow and as such I implemented `enrich/github_repository.rb`.

- Helper Task Modifications
  The helper task was enhanced to contain a new `extract_full_repo_name()` method which extracts the full repo name (intrigueio/intrigue-core) from a URI. This was written so in the future `extract_linked_hosts` task could be used to catch Github Repositories. Furthermore the `create_github_repo_entity()` method was refactored to only create the entity and allow the enrichment task to do the rest of the work.

Best regards,
Maxim