### PR TITLE
New sslcertificate format

### DIFF
--- a/lib/entities/ssl_certificate.rb
+++ b/lib/entities/ssl_certificate.rb
@@ -7,7 +7,7 @@ class SslCertificate < Intrigue::Core::Model::Entity
       name: "SslCertificate",
       description: "An SSL Certificate",
       user_creatable: false,
-      example: "test.intrigue.io (3695285271625093099202351562148679716)"
+      example: "intrigue.io (311448f91da5668ce8e4c1a7b49615e83f19c14ce7f7dd4088f32a6f97f56707)"
     }
   end
 
@@ -23,6 +23,7 @@ class SslCertificate < Intrigue::Core::Model::Entity
   # "subject": "#{cert.subject}",
   # "issuer": "#{cert.issuer}",
   # "algorithm": "#{cert.signature_algorithm}",
+  # "fingerprint_sha256" => "#{cert_sha256_fingerprint}",
   # "text": "#{cert.to_text}" }
   def detail_string
     "#{details["not_after"]} | #{details["subject"]} | #{details["issuer"]}"

--- a/lib/tasks/enrich/ssl_certificate.rb
+++ b/lib/tasks/enrich/ssl_certificate.rb
@@ -23,6 +23,7 @@ class SslCertificate < Intrigue::Task::BaseTask
             "subject" => "example",
             "issuer" => "example cert issuer",
             "algorithm" => "SHA256",
+            "fingerprint_sha256" => "b3d1c464976e725e599d3548180cb56311818f224e701f9d56f22e8079a7b396",
             "hidden_text" => "blah blah blah"
           }
         }

--- a/lib/tasks/helpers/certificate.rb
+++ b/lib/tasks/helpers/certificate.rb
@@ -19,11 +19,12 @@ module Intrigue
   
       # Parse the cert
       cert = OpenSSL::X509::Certificate.new(socket.peer_cert)
+      cert_sha256_fingerprint = OpenSSL::Digest::SHA256.new(cert.to_der).to_s
   
       # Create an SSL Certificate entity
       key_size = "#{cert.public_key.n.num_bytes * 8}" if cert.public_key && cert.public_key.respond_to?(:n)
       certificate_details = {
-        "name" => "#{cert.subject.to_s.split("CN=").last} (#{cert.serial})",
+        "name" => "#{cert.subject.to_s.split("CN=").last} (#{cert_sha256_fingerprint})",
         "version" => cert.version,
         "serial" => "#{cert.serial}",
         "not_before" => "#{cert.not_before}",
@@ -32,6 +33,7 @@ module Intrigue
         "issuer" => "#{cert.issuer}",
         "key_length" => key_size,
         "signature_algorithm" => "#{cert.signature_algorithm}",
+        "fingerprint_sha256" => "#{cert_sha256_fingerprint}",
         "hidden_text" => "#{cert.to_text}"
       }
   

--- a/lib/tasks/uri_gather_ssl_certificate.rb
+++ b/lib/tasks/uri_gather_ssl_certificate.rb
@@ -8,7 +8,7 @@ class UriGatherSslCert  < BaseTask
     {
       :name => "uri_gather_ssl_certificate",
       :pretty_name => "URI Gather SSL Certificate",
-      :authors => ["jcran"],
+      :authors => ["jcran","Anas Ben Salah"],
       :description => "Grab the SSL certificate from an application server",
       :references => [],
       :type => "discovery",
@@ -45,23 +45,6 @@ class UriGatherSslCert  < BaseTask
 
     # one way to detect self-signed
     if certificate_details["subject"] == certificate_details["issuer"]
-      ############################################
-      ####            Old Issue              ####
-      ###########################################
-      # _create_issue({
-      #   name: "Self-signed Certificate Detected",
-      #   severity: 5,
-      #   type: "self_signed_certificate",
-      #   status: "confirmed",
-      #   description: "The following site: #{uri} is configured with a self-signed certificate",
-      #   references: [
-      #     "https://security.stackexchange.com/questions/93162/how-to-know-if-certificate-is-self-signed/162263"
-      #   ],
-      #     details: { certificate: certificate_details }
-      # })
-      ############################################
-      ####            New Issue               ####
-      ############################################
       _create_linked_issue("self_signed_certificate",{
         proof: "The following site: #{uri} is configured with a self-signed certificate",
         detailed_description: "The following site: #{uri} is configured with a self-signed certificate",


### PR DESCRIPTION
Changing SslCertificate entity format from CN + serial number to CN + sha256 fingerprint  
![image](https://user-images.githubusercontent.com/35723779/129990802-a785bf29-3359-44f2-86a6-ca9fee9e5f85.png)
