### PR TITLE
Add log levels

### DIFF
--- a/app/models/logger.rb
+++ b/app/models/logger.rb
@@ -12,6 +12,8 @@ module Intrigue
 
         @@log_level = Intrigue::Core::System::Config.config['intrigue_task_log_level'] || 'fatal'
 
+        @@log_level = @@log_level.downcase
+
         def self.scope_by_project(name)
           named_project_id = Intrigue::Core::Model::Project.first(name: name).id
           where(project_id: named_project_id)
@@ -31,24 +33,24 @@ module Intrigue
         end
 
         def log_debug(message)
-          p ['verbose', 'debug'].include? @@log_level.downcase
-          _log "[D] #{message}\n" if ['verbose', 'debug'].include? @@log_level.downcase
+          p ['verbose', 'debug'].include? @@log_level
+          _log "[D] #{message}\n" if ['verbose', 'debug'].include? @@log_level
         end
 
         def log_good(message)
-          _log "[+] #{message}\n" if ['verbose', 'good', 'debug'].include? @@log_level.downcase
+          _log "[+] #{message}\n" if ['verbose', 'good', 'debug'].include? @@log_level
         end
 
         def log_error(message)
-          _log "[E] #{message}\n" if ['verbose', 'good', 'debug', 'warning', 'error'].include? @@log_level.downcase
+          _log "[E] #{message}\n" if ['verbose', 'good', 'debug', 'warning', 'error'].include? @@log_level
         end
 
         def log_warning(message)
-          _log "[W] #{message}\n" if ['verbose', 'good', 'debug', 'warning'].include? @@log_level.downcase
+          _log "[W] #{message}\n" if ['verbose', 'good', 'debug', 'warning'].include? @@log_level
         end
 
         def log_fatal(message)
-          _log "[F] #{message}\n" if ['verbose', 'good', 'debug', 'warning', 'error', 'fatal'].include? @@log_level.downcase
+          _log "[F] #{message}\n" if ['verbose', 'good', 'debug', 'warning', 'error', 'fatal'].include? @@log_level
         end
 
         private

--- a/app/models/logger.rb
+++ b/app/models/logger.rb
@@ -10,7 +10,7 @@ module Intrigue
         one_to_one :scan_result
         many_to_one :project
 
-        @@log_level = 'fatal'
+        @@log_level = Intrigue::Core::System::Config.config['intrigue_task_log_level'] || 'fatal'
 
         def self.scope_by_project(name)
           named_project_id = Intrigue::Core::Model::Project.first(name: name).id
@@ -19,7 +19,6 @@ module Intrigue
 
         def before_create
           self.location = Intrigue::Core::System::Config.config['intrigue_task_log_location'] || 'database'
-          @@log_level = Intrigue::Core::System::Config.config['intrigue_task_log_level'] || 'fatal'
           super
         end
 

--- a/app/models/logger.rb
+++ b/app/models/logger.rb
@@ -31,23 +31,24 @@ module Intrigue
         end
 
         def log_debug(message)
-          _log "[D] #{message}\n" if ['verbose', 'debug'].include? @@log_level
+          p ['verbose', 'debug'].include? @@log_level.downcase
+          _log "[D] #{message}\n" if ['verbose', 'debug'].include? @@log_level.downcase
         end
 
         def log_good(message)
-          _log "[+] #{message}\n" if ['verbose', 'good', 'debug'].include? @@log_level
+          _log "[+] #{message}\n" if ['verbose', 'good', 'debug'].include? @@log_level.downcase
         end
 
         def log_error(message)
-          _log "[E] #{message}\n" if ['verbose', 'good', 'debug', 'warning', 'error'].include? @@log_level
+          _log "[E] #{message}\n" if ['verbose', 'good', 'debug', 'warning', 'error'].include? @@log_level.downcase
         end
 
         def log_warning(message)
-          _log "[W] #{message}\n" if ['verbose', 'good', 'debug', 'warning'].include? @@log_level
+          _log "[W] #{message}\n" if ['verbose', 'good', 'debug', 'warning'].include? @@log_level.downcase
         end
 
         def log_fatal(message)
-          _log "[F] #{message}\n" if ['verbose', 'good', 'debug', 'warning', 'error', 'fatal'].include? @@log_level
+          _log "[F] #{message}\n" if ['verbose', 'good', 'debug', 'warning', 'error', 'fatal'].include? @@log_level.downcase
         end
 
         private

--- a/app/models/logger.rb
+++ b/app/models/logger.rb
@@ -1,80 +1,80 @@
 module Intrigue
-module Core
-module Model
-  class Logger < Sequel::Model
-    plugin :serialization, :json
-    plugin :validation_helpers
-    plugin :timestamps
+  module Core
+    module Model
+      class Logger < Sequel::Model
+        plugin :serialization, :json
+        plugin :validation_helpers
+        plugin :timestamps
 
-    one_to_one :task_result
-    one_to_one :scan_result
-    many_to_one :project
+        one_to_one :task_result
+        one_to_one :scan_result
+        many_to_one :project
 
-    def self.scope_by_project(name)
-      named_project_id = Intrigue::Core::Model::Project.first(:name => name).id
-      where(:project_id => named_project_id)
-    end
+        @@log_level = 'fatal'
 
-    def before_create
-      self.location = Intrigue::Core::System::Config.config["intrigue_task_log_location"] || "database"
-      super
-    end
-
-    def validate
-      super
-    end
-
-    def log(message)
-      _log "[_] #{message}\n"
-    end
-
-    def log_debug(message)
-      _log "[D] #{message}\n"
-    end
-
-    def log_good(message)
-      _log "[+] #{message}\n"
-    end
-
-    def log_error(message)
-      _log "[E] #{message}\n"
-    end
-
-    def log_warning(message)
-      _log "[W] #{message}\n"
-    end
-
-    def log_fatal(message)
-      _log "[F] #{message}\n"
-    end
-
-  private
-
-    def _log(message)
-      # if method is set to none, don't log anything
-      return if location == "none"
-
-      encoded_out = message.sanitize_unicode
-
-      if location == "database"
-        begin
-          # any other value, log to the database
-          update(:full_log => "#{full_log}#{encoded_out}")
-          save_changes
-        rescue Sequel::DatabaseError => e
-          puts "ERROR WRITING LOG FOR #{self}: #{e}"
+        def self.scope_by_project(name)
+          named_project_id = Intrigue::Core::Model::Project.first(name: name).id
+          where(project_id: named_project_id)
         end
 
-      elsif location == "file"
-        File.open("#{$intrigue_basedir}/log/#{task_result.id}.log","a"){|f| f.puts "#{encoded_out}"; } 
-      else
-        raise "Fatal! Unknown value for intrigue_task_log_location: #{intrigue_task_log_location}"
+        def before_create
+          self.location = Intrigue::Core::System::Config.config['intrigue_task_log_location'] || 'database'
+          @@log_level = Intrigue::Core::System::Config.config['intrigue_task_log_level'] || 'fatal'
+          super
+        end
+
+        def validate
+          super
+        end
+
+        def log(message)
+          _log "[_] #{message}\n" if @@log_level == 'verbose'
+        end
+
+        def log_debug(message)
+          _log "[D] #{message}\n" if ['verbose', 'debug'].include? @@log_level
+        end
+
+        def log_good(message)
+          _log "[+] #{message}\n" if ['verbose', 'good', 'debug'].include? @@log_level
+        end
+
+        def log_error(message)
+          _log "[E] #{message}\n" if ['verbose', 'good', 'debug', 'warning', 'error'].include? @@log_level
+        end
+
+        def log_warning(message)
+          _log "[W] #{message}\n" if ['verbose', 'good', 'debug', 'warning'].include? @@log_level
+        end
+
+        def log_fatal(message)
+          _log "[F] #{message}\n" if ['verbose', 'good', 'debug', 'warning', 'error', 'fatal'].include? @@log_level
+        end
+
+        private
+
+        def _log(message)
+          # if method is set to none, don't log anything
+          return if location == 'none'
+
+          encoded_out = message.sanitize_unicode
+
+          if location == 'database'
+            begin
+              # any other value, log to the database
+              update(full_log: "#{full_log}#{encoded_out}")
+              save_changes
+            rescue Sequel::DatabaseError => e
+              puts "ERROR WRITING LOG FOR #{self}: #{e}"
+            end
+
+          elsif location == 'file'
+            File.open("#{$intrigue_basedir}/log/#{task_result.id}.log", 'a') { |f| f.puts encoded_out.to_s; }
+          else
+            raise "Fatal! Unknown value for intrigue_task_log_location: #{intrigue_task_log_location}"
+          end
+        end
       end
-
     end
-
   end
-
-end
-end
 end

--- a/config/config.json.default
+++ b/config/config.json.default
@@ -18,7 +18,7 @@
   "sentry_dsn": null,
   "browser_enabled": true,
   "intrigue_task_log_location": "database",
-  "intrigue_task_log_level": "fatal",
+  "intrigue_task_log_level": "error",
   "intrigue_load_paths": [],
   "intrigue_handler_processing_wait_time": 60,
   "intrigue_notifiers": {

--- a/config/config.json.default
+++ b/config/config.json.default
@@ -18,6 +18,7 @@
   "sentry_dsn": null,
   "browser_enabled": true,
   "intrigue_task_log_location": "database",
+  "intrigue_task_log_level": "fatal",
   "intrigue_load_paths": [],
   "intrigue_handler_processing_wait_time": 60,
   "intrigue_notifiers": {


### PR DESCRIPTION
This will allow us to reduce the logging to just fatal logging or all the way up to verbose. Which in turn will reduce the amount of transactions going in to some extent.

Log_levels can take the following forms

verbose
debug
good
error
fatal

When turned to "fatal" only fatal logging will be logged, when turned to "error", both "error" and "fatal" will be logged and so on.

Adding anything other than the above will result in nothing being logged.

For the purpose of this I have left the default value to "error" which will allow us to log when something goes wrong and leave all the remaining verbose log out of the way unless needed.