### PR TITLE
Fixing some discovery task issues

### DIFF
--- a/lib/tasks/gitrob.rb
+++ b/lib/tasks/gitrob.rb
@@ -77,7 +77,7 @@ class Gitrob < BaseTask
     if output["Repositories"]
       output["Repositories"].each do |r|
         repo_entities << _create_entity("GithubRepository", {
-          "name" => "#{r["FullName"]}",
+          "name" => "#{r["URL"]}",
           "uri" => "#{r["URL"]}",
           "description" => "#{r["description"]}",
           "raw" => r

--- a/lib/tasks/search_psbdmp.rb
+++ b/lib/tasks/search_psbdmp.rb
@@ -41,7 +41,7 @@ class SearchPsbdmp < BaseTask
     entity_name = _get_entity_name
 
     #headers
-    headers = { "Accept" =>  "application/json"}
+    headers = { "Accept" =>  "application/json" }
 
     # Get responce
     response = http_get_body("https://psbdmp.ws/api/v3/search/#{entity_name}",nil,headers)
@@ -67,16 +67,15 @@ class SearchPsbdmp < BaseTask
       # Create an issue if we have visible data
       if !response_body.include? "Forbidden (#403)" and !response_body.include? "Not Found (#404)"
 
-        issue_hash = { source: paste_uri,  proof: response_body}
+        issue_hash = { source: paste_uri, proof: response_body }
 
         # Check for specific keyword if it is included in the paste to increase the severity level
         if !high_severity_keywords.select{|x| response_body =~ x }.empty?
           # create linked issue with a higher severity
-          issue_hash.merge!( severity: 3 )
+          issue_hash.merge!(severity: 3)
         end
 
-        # create linked issue
-        _create_linked_issue "suspicious_pastebin",  {proof: issue_hash}
+        _create_linked_issue("suspicious_pastebin", issue_hash)
 
       end
     end


### PR DESCRIPTION
Found some issues with two tasks:

1.) `Gitrob`:

The task was throwing the following error:

```
[E] Invalid entity attempted Invalid entity, unable to validate: GithubRepository#intrigueio/intrigue-core
```

The bug is that the task is trying to create the entity using the old fashioned naming convention. Needed to change `FullName` to `URL`.

Kudos to @m-q-t for catching that.

2.) `Search Psbdmp`:

During linked issue creation the details were defined / added in a way that it led to the created issues overwriting each other. A little re-arrangement fixed that.