### PR TITLE
Shodan Support Netblocks

### DIFF
--- a/lib/client/search/shodan.rb
+++ b/lib/client/search/shodan.rb
@@ -23,6 +23,38 @@ module Client
           end
           response
         end
+
+        def search_netblock(string)
+          full_json_response = []
+
+          req_uri = -> (page) { "https://api.shodan.io/shodan/host/search?key=#{@api_key}&query=net:#{string}&page=#{page}" }
+          response = _shodan_pagination(req_uri.call(1))
+
+          return if response.nil?
+          return if response['total'].zero?
+
+          full_json_response << response['matches'] # concat matches into array
+          total_pages = (response['total'].to_i / 100.to_f).ceil # get amount of total pages rounded up
+
+          return { 'data' => full_json_response.flatten } if total_pages == 1 # only one page < 100 results; return 
+
+          (2..total_pages).each do |i|
+            response = _shodan_pagination(req_uri.call(i))
+            next if response.nil?
+
+            full_json_response << response['matches']
+            sleep(1) # do not upset Shodan
+          end
+
+          { 'data' => full_json_response.flatten }
+        end
+
+        def _shodan_pagination(request)
+          JSON.parse(Typhoeus.get(request).body)
+        rescue Timeout::Error, JSON::ParserError
+          _log_error 'Unable to parse JSON response for Shodan API request'
+        end
+
         ### search an IP if it is a honeypot or a real control system.
         def search_honeypot_ip(string)
           begin
@@ -32,7 +64,7 @@ module Client
           end
           response
         end
-
+        
       end
     end
     end

--- a/lib/tasks/search_shodan.rb
+++ b/lib/tasks/search_shodan.rb
@@ -1,96 +1,85 @@
 module Intrigue
-module Task
-class SearchShodan < BaseTask
-
-  def self.metadata
-    {
-      :name => "search_shodan",
-      :pretty_name => "Search Shodan",
-      :authors => ["jcran"],
-      :description => "Uses the SHODAN API to search for information",
-      :references => [],
-      :type => "discovery",
-      :passive => true,
-      :allowed_types => ["IpAddress"],
-      :example_entities => [
-        {"type" => "String", "details" => {"name" => "intrigue.io"}}
-      ],
-      :allowed_options => [],
-      :created_types => ["DnsRecord","IpAddress","NetworkService","Organization","PhysicalLocation"]
-    }
-  end
-
-  ## Default method, subclasses must override this
-  def run
-    super
-
-    # Get the API Key
-    api_key = _get_task_config "shodan_api_key"
-    search_term = _get_entity_name
-
-    client = Client::Search::Shodan::ApiClient.new(api_key)
-    response = client.search_ip(search_term)
-
-    # check to make sure we got a response.
-    unless response && response["data"]
-      _log_error "ERROR: #{response}"
-      return false
-    end
-
-    # Go through the results
-    _set_entity_detail("extended_shodan",response["data"])
-
-    response["data"].each do |resp|
-
-      # create an entity for each service (this handles known aliases), save the raw data
-      response["data"].each do |s|
-        _log_good "Creating service on #{s["ip_str"]}: #{s["port"]}"
-        _create_network_service_entity(@entity, s["port"], s["transport"] || "tcp", {
-          "shodan_timestamp" => resp["timestamp"],
-          "extended_shodan" => resp } )
+  module Task
+    class SearchShodan < BaseTask
+      def self.metadata
+        {
+          name: 'search_shodan',
+          pretty_name: 'Search Shodan',
+          authors: ['jcran'],
+          description: 'Uses the SHODAN API to search for information',
+          references: [],
+          type: 'discovery',
+          passive: true,
+          allowed_types: ['IpAddress', 'NetBlock'],
+          example_entities: [
+            { 'type' => 'IpAddres', 'details' => { 'name' => 'intrigue.io' } }
+          ],
+          allowed_options: [],
+          created_types: ['DnsRecord', 'IpAddress', 'NetworkService', 'Organization', 'PhysicalLocation']
+        }
       end
 
-      # Create all hostnames
-      resp["hostnames"].each do |h|
-        _log_good "Creating dns record: #{h}"
-        #_create_entity "DnsRecord", "name" => "#{h}"
-        create_dns_entity_from_string h
+      ## Default method, subclasses must override this
+      def run
+        super
+
+        # Get the API Key
+        api_key = _get_task_config 'shodan_api_key'
+        search_term = _get_entity_name
+        entity_type = _get_entity_type_string
+
+        client = Client::Search::Shodan::ApiClient.new(api_key)
+        response = entity_type == 'IpAddress' ? client.search_ip(search_term) : client.search_netblock(search_term)
+
+        # check to make sure we got a response.
+        unless response && response['data']
+          _log_error "ERROR: #{response}"
+          return false
+        end
+
+        # Go through the results
+        _set_entity_detail('extended_shodan', response['data'])
+
+        response['data'].each do |s|
+          next if s['port'].nil?
+
+          _log_good "Creating service on #{s['ip_str']}: #{s['port']}"
+
+          e = @entity # no need to enrich if original entity was an IP Address
+          e = _create_entity 'IpAddress', { 'name' => s['ip_str'] } if entity_type == 'NetBlock'
+
+          _create_network_service_entity(e, s['port'], s['transport'] || 'tcp', {
+                                           'shodan_timestamp' => s['timestamp'],
+                                           'extended_shodan' => s
+                                         })
+
+          s['hostnames']&.each { |h| create_dns_entity_from_string(h) }
+          # check_if_honeypot(s['ip_str'])
+        end
       end
 
-      # search Ip if it a honeypot
-      response_honeyscore = client.search_ip(search_term)
-
-      # check to make sure we got a response.
-      unless response
-        _log_error "ERROR: could not get response from Shodan.io"
-        return false
-      end
-
-      if response_honeyscore == "1.0"
-        _create_linked_issue("honeypot_detected",{
-        proof: response,
-        source:"shodan.io" ,
-        references: ["https://honeyscore.shodan.io/"] })
-      else
-        return false
-      end
+      # honeypot api endpoint has been deprecated
+      # come back & fix later
+      # if response_honeyscore == "1.0"
+      #   _create_linked_issue("honeypot_detected",{
+      #   proof: response,
+      #   source:"shodan.io" ,
+      #   references: ["https://honeyscore.shodan.io/"] })
+      # else
+      #   return false
+      # end
 
       # Create all domains
-      #resp["domains"].each do |d|
+      # resp["domains"].each do |d|
       #  _log_good "Creating domain: #{d}"
       #  check_and_create_unscoped_domain d
-      #end
+      # end
 
       # Create the organization if we have it
-      #if resp["org"]
+      # if resp["org"]
       #  _log_good "Creating organization: #{resp["org"]}"
       #  _create_entity "Organization", "name" => "#{resp["org"]}"
-      #end
-
+      # end
     end
-
   end
-
-end
-end
 end


### PR DESCRIPTION
Hi team,

Please find attached in the PR the changes made to extend the `search_shodan` task to support netblocks. In order to make this possible, the `search_netblock()` helper method was added to the Shodan API Client. The `search_shodan` task was partially refactored to  seamlessly integrate the netblocks support.

The task can use a bit more cleaning up however due to time constraints this is not a priority and can be revisited later.

Best regards,
Maxim