### PR TITLE
Tweaks for export scale

### DIFF
--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -463,13 +463,13 @@ module Model
         :detail_string => detail_string,
         :details => export_details,
         :ancestors => ancestors.map{|x| { "type" => x.type, "name" => x.name }},
-        :task_results => task_results.first(25).map{ |t|
+        :task_results => task_results.select{|x| !x.name =~ /^enrich/ }.first(100).map{ |t|
           { :id => t.id,
             :name => t.name,
             #:task_type => t.task_type,
             :base_entity_name => t.base_entity.name,
             :base_entity_type => t.base_entity.type  }
-        },
+          },
         :enrichment_tasks => enrichment_tasks,
         :generated_at => Time.now.utc.iso8601
       }

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -463,7 +463,7 @@ module Model
         :detail_string => detail_string,
         :details => export_details,
         :ancestors => ancestors.map{|x| { "type" => x.type, "name" => x.name }},
-        :task_results => task_results.map{ |t|
+        :task_results => task_results.first(25).map{ |t|
           { :id => t.id,
             :name => t.name,
             #:task_type => t.task_type,

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -71,7 +71,7 @@ module Model
         :references =>  details["references"],
         :entity_type => entity.type,
         :entity_name => entity.name,
-        :entity_aliases => entity.aliases.map{|a| {"type" => a.type, "name" => a.name} },
+        #:entity_aliases => entity.aliases.map{|a| {"type" => a.type, "name" => a.name} },
         :entity_alias_group_id => entity.alias_group_id,
         :details => details,
         :task_result => "#{task_result.name if task_result}",


### PR DESCRIPTION
Two changes to help deal with issues we're running into on hosted service. 

1) For large collections where entities have many many aliases, the change to issue export will help, without reducing fidelity of info since we have the alias_group_id to reconstruct. 

2) For entities with many tasks creating them, this can sometimes cause entity sizes to blow up. For now (and this is probably a temporary fix to the problem), limit the list of exported task results to those that are not enrich tasks, and the first 100 only
