### PR TITLE
Support for AWS Credential Temporary Keys

### DIFF
--- a/lib/tasks/aws_ec2_gather_instances.rb
+++ b/lib/tasks/aws_ec2_gather_instances.rb
@@ -24,11 +24,13 @@ module Intrigue
         super
 
         # Get the AWS Credentials
-        aws_access_key, aws_secret_key = get_aws_keys_from_entity_type(_get_entity_type_string)
-        return unless aws_access_key && aws_secret_key
+        aws_keys = get_aws_keys_from_entity_type(_get_entity_type_string)
+        return unless aws_keys.access_key && aws_keys.secret_key
+
         aws_region = _get_option 'region'
 
-        ec2 = Aws::EC2::Resource.new(region: aws_region, access_key_id: aws_access_key, secret_access_key: aws_secret_key)
+        ec2 = Aws::EC2::Resource.new(region: aws_region, access_key_id: aws_keys.access_key,
+                                     secret_access_key: aws_keys.secret_key, session_token: aws_keys.session_token)
 
         begin
           instances = ec2.instances

--- a/lib/tasks/aws_iam_gather_accounts.rb
+++ b/lib/tasks/aws_iam_gather_accounts.rb
@@ -22,11 +22,12 @@ module Intrigue
         super
 
         # Get the AWS Credentials
-        aws_access_key, aws_secret_key = get_aws_keys_from_entity_type(_get_entity_type_string)
-        return unless aws_access_key && aws_secret_key
+        aws_keys = get_aws_keys_from_entity_type(_get_entity_type_string)
+        return unless aws_keys.access_key && aws_keys.secret_key
 
         # IAM is global so region is not needed
-        iam = Aws::IAM::Client.new({ region: 'us-east-1', access_key_id: aws_access_key, secret_access_key: aws_secret_key })
+        iam = Aws::IAM::Client.new({ region: 'us-east-1', access_key_id: aws_keys.access_key,
+                                     secret_access_key: aws_keys.secret_key, session_token: aws_keys.session_token })
 
         begin
           groups = iam.list_groups

--- a/lib/tasks/aws_route53_gather_records.rb
+++ b/lib/tasks/aws_route53_gather_records.rb
@@ -1,9 +1,9 @@
 module Intrigue
   module Task
-    class AwsRoute53 < BaseTask
+    class AwsRoute53GatherRecords < BaseTask
       def self.metadata
         {
-          name: 'aws_route53',
+          name: 'aws_route53_gather_records',
           pretty_name: 'AWS Route53 Gather Records',
           authors: ['Anas Ben Salah', 'maxim'],
           description: 'This task hits the Route53 API for enumerating DNS Records. Please ensure the <i>ListResourceRecordSets</i> permission is set in the policy for which the keys are associated with in order to retrieve records from a Hosted Zone. <br/><br/><b>Please note that if no Hosted Zone ID is provided; this task will retrieve records for all accessible Hosted Zones.</b>',
@@ -25,12 +25,13 @@ module Intrigue
         super
 
         # Get the AWS Credentials
-        aws_access_key, aws_secret_key = get_aws_keys_from_entity_type(_get_entity_type_string)
-        return unless aws_access_key && aws_secret_key
-        hosted_zone_id = _get_option 'Hosted Zone ID'
+        aws_keys = get_aws_keys_from_entity_type(_get_entity_type_string)
+        return unless aws_keys.access_key && aws_keys.secret_key
 
+        hosted_zone_id = _get_option 'Hosted Zone ID'
         # route53 is global; region does not matter. set to us-east-1 to satisfy SDK.
-        r53 = Aws::Route53::Client.new({ region: 'us-east-1', access_key_id: aws_access_key, secret_access_key: aws_secret_key })
+        r53 = Aws::Route53::Client.new({ region: 'us-east-1', access_key_id: aws_keys.access_key,
+                                         secret_access_key: aws_keys.secret_key, session_token: aws_keys.session_token })
 
         return nil unless access_key_valid? r53
 

--- a/lib/tasks/aws_s3_gather_buckets.rb
+++ b/lib/tasks/aws_s3_gather_buckets.rb
@@ -22,12 +22,13 @@ module Intrigue
         super
 
         # Get the AWS Credentials
-        aws_access_key, aws_secret_key = get_aws_keys_from_entity_type(_get_entity_type_string)
-        return unless aws_access_key && aws_secret_key
+        aws_keys = get_aws_keys_from_entity_type(_get_entity_type_string)
+        return unless aws_keys.access_key && aws_keys.secret_key
         
         # when querying account for buckets; region doesn't make a difference so we use us-east-1 by default
         _log "Getting S3 buckets..."
-        s3 = Aws::S3::Resource.new(region: 'us-east-1', access_key_id: aws_access_key, secret_access_key: aws_secret_key)
+        s3 = Aws::S3::Resource.new(region: 'us-east-1', access_key_id: aws_keys.access_key, 
+                                   secret_access_key: aws_keys.secret_key, session_token: aws_keys.session_token)
 
         begin
           bucket_names = s3.buckets.collect(&:name) # collect the buckets from the account

--- a/lib/tasks/helpers/aws.rb
+++ b/lib/tasks/helpers/aws.rb
@@ -80,26 +80,20 @@ module Intrigue
 
 
       def get_aws_keys_from_entity_type(entity_type)
-        if entity_type == "AwsCredential"
+        if entity_type == 'AwsCredential'
           aws_access_key = _get_entity_sensitive_detail 'aws_access_key_id'
           aws_secret_key = _get_entity_sensitive_detail 'aws_secret_access_key'
-        elsif entity_type == "String"
+          aws_session_token = _get_entity_sensitive_detail 'aws_session_token'
+        elsif entity_type == 'String'
           aws_access_key = _get_task_config('aws_access_key_id')
           aws_secret_key = _get_task_config('aws_secret_access_key')
-        else
-          aws_access_key = nil
-          aws_secret_key = nil
         end
 
-        # if empty string return nil
-        if aws_access_key == ""
-          aws_access_key = nil
-        end
-        if aws_secret_key == ""
-          aws_secret_key = nil
-        end
+        aws_access_key = nil if aws_access_key&.empty?
+        aws_secret_key = nil if aws_secret_key&.empty?
+        aws_session_token = nil if aws_session_token&.empty?
 
-        return aws_access_key, aws_secret_key
+        Struct.new(:access_key, :secret_key, :session_token).new(aws_access_key, aws_secret_key, aws_session_token)
       end
 
       def extract_bucket_name_from_string(str)


### PR DESCRIPTION
Hi team,

Please find attached in this PR the implementation to allow the AWS tasks to support AWS Temporary Keys (generated via STS).

Changes:
- The `get_aws_keys_from_entity_type()` helper was refactored in order to support AWS Temporary Keys. The main difference between access keys and temporary keys is that temporary keys include a session token.
  - One thing to note here is that only the `AwsCredential` entity will support AWS Temporary Keys. The reason behind this is because it doesn't make too much sense adding temporary keys to the task.config when compared to normal access keys.

- Every task which is a caller of `get_aws_keys_from_entity_type()` has been extended to now support the session token which includes:
  - aws_ec2_gather_instances.rb
  - aws_iam_gather_accounts.rb
  - aws_route53_gather_records.rb
  - aws_s3_gather_buckets.rb

- The `aws_route53.rb` task was renamed to `aws_route53_gather_records.rb` in order to follow the naming convention.

Thanks.

Best regards,
Maxim


