### PR TITLE
Networkservice confirm openport

### DIFF
--- a/lib/tasks/enrich/network_service.rb
+++ b/lib/tasks/enrich/network_service.rb
@@ -43,7 +43,7 @@ class NetworkService < Intrigue::Task::BaseTask
 
     # check if the port is open, if not, hide this entity (its not a real NetworkService)
     unless _get_entity_detail("hidden_port_open_confirmed") == true
-      unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_address, port)
+      unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_address, port, 5)
         # note that we use tcp even for udp ports, because with udp we fire & hope for the best
         # this has been tested and tcp is reliable for detecting open udp ports
         hide_value = true

--- a/lib/tasks/enrich/network_service.rb
+++ b/lib/tasks/enrich/network_service.rb
@@ -42,20 +42,21 @@ class NetworkService < Intrigue::Task::BaseTask
     net_name = _get_entity_detail("net_name")
 
     # check if the port is open, if not, hide this entity (its not a real NetworkService)
-    unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_address, port)
-      # note that we use tcp even for udp ports, because with udp we fire & hope for the best
-      # this has been tested and tcp is reliable for detecting open udp ports
-      hide_value = true
-      hide_reason = "port_closed"
-      _set_entity_detail "hide_value", hide_value
-      _set_entity_detail "hide_reason", hide_reason
+    unless _get_entity_detail("hidden_port_open_confirmed") == true
+      unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_address, port)
+        # note that we use tcp even for udp ports, because with udp we fire & hope for the best
+        # this has been tested and tcp is reliable for detecting open udp ports
+        hide_value = true
+        hide_reason = "port_closed"
+        _set_entity_detail "hide_value", hide_value
+        _set_entity_detail "hide_reason", hide_reason
 
-      # Okay now hide based on our value
-      _log "Setting Hidden to: #{hide_value}, for reason: #{hide_reason}"
-      @entity.hidden = hide_value
-      @entity.save_changes
-      return
-
+        # Okay now hide based on our value
+        _log "Setting Hidden to: #{hide_value}, for reason: #{hide_reason}"
+        @entity.hidden = hide_value
+        @entity.save_changes
+        return
+      end
     end 
     
     _set_entity_detail("ip_address", ip_address)

--- a/lib/tasks/enrich/network_service.rb
+++ b/lib/tasks/enrich/network_service.rb
@@ -41,6 +41,23 @@ class NetworkService < Intrigue::Task::BaseTask
     proto = entity_name.split(":").last.split("/").first.upcase
     net_name = _get_entity_detail("net_name")
 
+    # check if the port is open, if not, hide this entity (its not a real NetworkService)
+    unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_address, port)
+      # note that we use tcp even for udp ports, because with udp we fire & hope for the best
+      # this has been tested and tcp is reliable for detecting open udp ports
+      hide_value = true
+      hide_reason = "port_closed"
+      _set_entity_detail "hide_value", hide_value
+      _set_entity_detail "hide_reason", hide_reason
+
+      # Okay now hide based on our value
+      _log "Setting Hidden to: #{hide_value}, for reason: #{hide_reason}"
+      @entity.hidden = hide_value
+      @entity.save_changes
+      return
+
+    end 
+    
     _set_entity_detail("ip_address", ip_address)
     _set_entity_detail("port", port)
     _set_entity_detail("proto", proto)

--- a/lib/tasks/helpers/services.rb
+++ b/lib/tasks/helpers/services.rb
@@ -60,7 +60,7 @@ module Services
       "asn" => ip_entity.get_detail("asn"),
       "net_name" => ip_entity.get_detail("net_name"),
       "net_country_code" => ip_entity.get_detail("net_country_code"),
-      "host_id" => ip_entity.id
+      "host_id" => ip_entity.id,
       "hidden_port_open_confirmed" => true # is needed so enrich doesn't check the open port again
     })
 

--- a/lib/tasks/helpers/services.rb
+++ b/lib/tasks/helpers/services.rb
@@ -32,6 +32,11 @@ module Services
 
   def _create_network_service_entity(ip_entity,port_num,protocol="tcp",generic_details={})
 
+    # before anything, check if port is open and return nil if not
+    # note that we use tcp even for udp ports, because with udp we fire & hope for the best
+    # this has been tested and tcp is reliable for detecting open udp ports
+    return nil unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_entity, port_num)
+
     # first, save the port details on the ip_entity
     ports = ip_entity.get_detail("ports") || []
     updated_ports = ports.append({"number" => port_num, "protocol" => protocol}).uniq

--- a/lib/tasks/helpers/services.rb
+++ b/lib/tasks/helpers/services.rb
@@ -35,7 +35,7 @@ module Services
     # before anything, check if port is open and return nil if not
     # note that we use tcp even for udp ports, because with udp we fire & hope for the best
     # this has been tested and tcp is reliable for detecting open udp ports
-    return nil unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_entity, port_num)
+    return nil unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_entity, port_num, 5)
 
 
     # first, save the port details on the ip_entity

--- a/lib/tasks/helpers/services.rb
+++ b/lib/tasks/helpers/services.rb
@@ -37,6 +37,7 @@ module Services
     # this has been tested and tcp is reliable for detecting open udp ports
     return nil unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_entity, port_num)
 
+
     # first, save the port details on the ip_entity
     ports = ip_entity.get_detail("ports") || []
     updated_ports = ports.append({"number" => port_num, "protocol" => protocol}).uniq
@@ -60,6 +61,7 @@ module Services
       "net_name" => ip_entity.get_detail("net_name"),
       "net_country_code" => ip_entity.get_detail("net_country_code"),
       "host_id" => ip_entity.id
+      "hidden_port_open_confirmed" => true # is needed so enrich doesn't check the open port again
     })
 
     # if this is an ssl port, let's get the CNs and create dns records


### PR DESCRIPTION
This PR checks and confirms the port is open before creating a NetworkService entity. It does so in two places:
1. in `lib/tasks/helpers/services.rb` (function "_create_network_service_entity")
2. in `enrich/network_service.rb`

The reason to do it in enrich is to catch cases where the _create_network_service_entity helper is not being used. I set a hidden field in the entity so that we don't check the port twice. Its a bit ugly but should do the trick