### PR TITLE
GitlabCredential Entity Support

### DIFF
--- a/lib/entities/gitlab_credential.rb
+++ b/lib/entities/gitlab_credential.rb
@@ -1,0 +1,25 @@
+module Intrigue
+  module Entity
+    class GitlabCredential < Intrigue::Core::Model::Entity
+      def self.metadata
+        {
+          name: 'GitlabCredential',
+          description: 'Gitlab Credential',
+          sensitive: true
+        }
+      end
+
+      def validate_entity
+        sensitive_details['gitlab_host'] && sensitive_details['gitlab_access_token']
+      end
+
+      def scoped?
+        return true if scoped
+        return true if allow_list || project.allow_list_entity?(self)
+        return false if deny_list || project.deny_list_entity?(self)
+
+        true # otherwise just default to true
+      end
+    end
+  end
+end

--- a/lib/tasks/gather_gitlab_projects.rb
+++ b/lib/tasks/gather_gitlab_projects.rb
@@ -68,7 +68,7 @@ module Intrigue
         elsif _get_entity_type_string == 'GitlabAccount'
           group = is_gitlab_group?(info.host, info.account, info.token)
           if group
-           ->(x) { "#{info.host}/api/v4/group/#{info.account}/projects?page=#{x}&simple=true&per_page=100" }
+           ->(x) { "#{info.host}/api/v4/groups/#{info.account}/projects?page=#{x}&simple=true&per_page=100" }
           else
             ->(x) { "#{info.host}/api/v4/users/#{info.account}/projects?page=#{x}&simple=true&per_page=100" }
           end

--- a/lib/tasks/gather_gitlab_projects.rb
+++ b/lib/tasks/gather_gitlab_projects.rb
@@ -10,8 +10,9 @@ module Intrigue
           references: ['https://docs.gitlab.com/ee/api/'],
           type: 'discovery',
           passive: false,
-          allowed_types: ['GitlabAccount'],
-          example_entities: [{ 'type' => 'GitlabAccount', 'details' => { 'name' => 'https://gitlab.intrigue.io/account' } }],
+          allowed_types: ['GitlabAccount', 'GitlabCredential'],
+          example_entities: [{ 'type' => 'GitlabAccount', 'details' => { 'name' => 'https://gitlab.intrigue.io/account' }},
+                             { 'type' => 'GitlabCredential', 'details' => { 'name' => 'GitlabCreds1' }} ],
           allowed_options: [],
           created_types: ['GitlabProject']
         }
@@ -21,19 +22,80 @@ module Intrigue
       def run
         super
 
-        parameters = _create_parameters_from_gitlab_uri
-        return if parameters.nil?
+        entity_info = parse_entity_information(_get_entity_type_string)
+        return if entity_info.nil?
 
-        parameters.token = retrieve_gitlab_token(parameters.host) || ''
-
-        projects = gather_gitlab_projects(parameters)
+        projects = gather_gitlab_projects(entity_info)
         _log "Gathered #{projects.size} projects!"
         return if projects.empty?
 
         projects.each { |r| _create_entity('GitlabProject', { 'name' => r }) }
       end
 
-      def _create_parameters_from_gitlab_uri
+      def gather_gitlab_projects(entity_info)
+        projects = []
+
+        api_call_builder = return_uri_builder(entity_info)
+        headers = { 'PRIVATE-TOKEN' => entity_info.token } if entity_info.token
+
+        total_requests = _return_total_requests(api_call_builder, headers)
+        return projects if total_requests.nil?
+
+        (1..total_requests).each do |page|
+          _log "Getting results from Page #{page}"
+          outcome = _make_api_call(api_call_builder.call(page), headers, projects)
+          break if outcome.nil?
+        end
+
+        projects.flatten.compact
+      end
+
+      def _make_api_call(uri, headers, output)
+        r = http_request(:get, uri, nil, headers)
+
+        return if _api_request_limit_exhausted?(r)
+
+        parsed_response = _parse_json_response(r.body)
+        return if parsed_response.nil? || parsed_response.empty?
+
+        sleep(2) # sleep to avoid triggering rate limiting
+        output << parsed_response&.map { |j| j['web_url'] } # in case any random response returned; use safe nil nav
+      end
+
+      def return_uri_builder(info)
+        if _get_entity_type_string == 'GitlabCredential'
+          ->(x) { "#{info.host}/api/v4/projects?page=#{x}&simple=true&owned=true&per_page=100" }
+        elsif _get_entity_type_string == 'GitlabAccount'
+          group = is_gitlab_group?(info.host, info.account, info.token)
+          if group
+           ->(x) { "#{info.host}/api/v4/group/#{info.account}/projects?page=#{x}&simple=true&per_page=100" }
+          else
+            ->(x) { "#{info.host}/api/v4/users/#{info.account}/projects?page=#{x}&simple=true&per_page=100" }
+          end
+        end
+      end
+
+      def parse_entity_information(entity_type)
+        if entity_type == 'GitlabCredential'
+          _parse_gitlab_credential_entity
+        elsif entity_type == 'GitlabAccount'
+          _parse_gitlab_account_entity
+        end
+      end
+
+      def _parse_gitlab_credential_entity
+        host = _get_entity_sensitive_detail('gitlab_host')
+        access_token = retrieve_gitlab_token(host, 'GitlabCredential')
+
+        if access_token.nil?
+          _log_error 'Valid access token required when using GitlabCredential entity.'
+          return
+        end
+
+        Struct.new(:host, :token).new(host, access_token)
+      end
+
+      def _parse_gitlab_account_entity
         parsed_uri = parse_gitlab_uri(_get_entity_name, 'account')
         parsed_uri.account.gsub!('/', '%2f') # urlencode / if its a project name
 
@@ -42,37 +104,13 @@ module Intrigue
           return
         end
 
+        parsed_uri.token = retrieve_gitlab_token(parsed_uri.host, 'GitlabAccount') || ''
+
         parsed_uri
       end
 
-      def gather_gitlab_projects(parameters)
-        projects = []
-
-        headers = { 'PRIVATE-TOKEN' => parameters.token } if parameters.token
-        uri = _generate_gitlab_api_uri(parameters.host, parameters.account, parameters.token)
-
-        total_requests = _total_requests(uri, headers)
-        return projects if total_requests.nil?
-
-        _log "There are a total of #{total_requests} pages which will be queried."
-        (1..total_requests).each do |page| # max 100 pages in ca  se something goes wrong
-          _log "Getting results from Page #{page}"
-          r = http_request(:get, "#{uri}?page=#{page}&per_page=100&simple=true", nil, headers)
-
-          break if _api_request_limit_exhausted?(r) # exhausted total number of requests
-
-          parsed_response = _parse_json_response(r.body)
-          break if parsed_response.nil? || parsed_response.empty?
-
-          projects << parsed_response&.map { |j| j['web_url'] } # in case any random response returned; use safe nil nav
-          sleep(2) # sleep to avoid triggering rate limiting
-        end
-
-        projects.flatten.compact
-      end
-
-      def _total_requests(uri, headers)
-        r = http_request(:get, "#{uri}?page=1&per_page=100&simple=true", nil, headers)
+      def _return_total_requests(uri, headers)
+        r = http_request(:get, uri.call(1), nil, headers)
         return unless _first_request_checklist(r)
 
         r.headers.fetch('x-total-pages')&.to_i
@@ -100,20 +138,11 @@ module Intrigue
         exhausted
       end
 
-      def _generate_gitlab_api_uri(host, account, access_token)
-        if is_gitlab_group?(host, account, access_token)
-          "#{host}/api/v4/groups/#{account}/projects"
-        else
-          "#{host}/api/v4/users/#{account}/projects"
-        end
-      end
-
       def _parse_json_response(response)
         JSON.parse(response)
       rescue JSON::ParserError
         _log_error 'Unable to parse JSON'
       end
-
     end
   end
 end


### PR DESCRIPTION
Hi team,

Please find attached the PR which adds support for the `GitlabCredential` entity. In order to support this entity, the task had to be slightly refactored to include an additional API route.

The original specs https://github.com/intrigueio/intrigue-core/blob/develop/spec/integration/gitlab_gather_projects.rb can be used to validate the task.

Here is a snippet of the bootstrap config which will add a `GitlabCredential` entity:

```
"seeds": [{
	"entity": "GitlabCredential#MyCreds1",
	"sensitive_details": {
		"gitlab_host": "https://gitlab.com",
		"gitlab_access_token": "EXAMPLE"
	}
},
{
	"entity": "GitlabCredential#gnome",
	"sensitive_details": {
		"gitlab_host": "https://gitlab.gnome.org",
		"gitlab_access_token": "EXAMPLE"
	}
}
]
```

Thank you.

Best regards,
Maxim