### PR TITLE
GithubCredential Entity Support

### DIFF
--- a/lib/entities/github_credential.rb
+++ b/lib/entities/github_credential.rb
@@ -1,0 +1,25 @@
+module Intrigue
+  module Entity
+    class GithubCredential < Intrigue::Core::Model::Entity
+      def self.metadata
+        {
+          name: 'GithubCredential',
+          description: 'Github Credential',
+          sensitive: true
+        }
+      end
+
+      def validate_entity
+        sensitive_details['github_access_token']
+      end
+
+      def scoped?
+        return true if scoped
+        return true if allow_list || project.allow_list_entity?(self)
+        return false if deny_list || project.deny_list_entity?(self)
+
+        true # otherwise just default to true
+      end
+    end
+  end
+end

--- a/lib/tasks/gather_github_repositories.rb
+++ b/lib/tasks/gather_github_repositories.rb
@@ -43,8 +43,11 @@ module Intrigue
 
         (1..10).each do |i|
           r = _github_api_call(construct_api_uri.call(i), client&.access_token)
-          preflight = preflight_check(r) if i == 1
-          break unless preflight
+
+          if i == 1
+            preflight = preflight_check(r) if i == 1
+            break unless preflight
+          end
 
           parsed_r = _parse_json_response(r.body)
           break if parsed_r.nil? || parsed_r.equal?('rate_exhaustion') 

--- a/lib/tasks/gather_github_repositories.rb
+++ b/lib/tasks/gather_github_repositories.rb
@@ -12,9 +12,10 @@ module Intrigue
           references: ['https://docs.github.com/en/rest'],
           type: 'discovery',
           passive: true,
-          allowed_types: ['String', 'GithubAccount'],
+          allowed_types: ['String', 'GithubAccount', 'GithubCredential'],
           example_entities: [{ 'type' => 'String', 'details' => { 'name' => '__IGNORE__', 'default' => '__IGNORE__' } },
-                             { 'type' => 'GithubAccount', 'details' => { 'name' => 'intrigueio', 'default' => 'https://github.com/intrigueio' } }],
+                             { 'type' => 'GithubAccount', 'details' => { 'name' => 'intrigueio', 'default' => 'https://github.com/intrigueio' } },
+                             { 'type' => 'GithubCredential', 'details' => { 'name' => 'GithubCreds1', 'default' => 'GithubCreds1' } }],
           allowed_options: [{ name: 'ignore_forks', regex: 'boolean', default: false }],
           created_types: ['GithubRepository'],
           queue: 'task_github'
@@ -25,7 +26,7 @@ module Intrigue
       def run
         super
 
-        gh_client = initialize_gh_client
+        gh_client = initialize_gh_client(_get_entity_type_string)
         repos = retrieve_repositories(gh_client)
         _log "Results obtained: #{repos.size}"
         return if repos.empty?
@@ -68,7 +69,7 @@ module Intrigue
         good = true
         case response.code
         when '401'
-          _log_error 'Authentication is required when using a String entity.'
+          _log_error 'Authentication is required when using a String/GithubCredential entity.'
           good = false
         when '422'
           _log_error 'Github Account does not exist; aborting.'
@@ -80,7 +81,7 @@ module Intrigue
       ## returns a lambda when passed a page number will construct the appropriate api route
       ## the api route is based on whether task is ran directly on key or a githubaccount entity
       def determine_api_route(entity_type)
-        if entity_type == 'String'
+        if ['String', 'GithubCredential'].include?(entity_type)
           ->(x) { "https://api.github.com/user/repos?type=all&per_page=100&page=#{x}" }
         elsif entity_type == 'GithubAccount'
           account_name = extract_github_account_name(_get_entity_name)

--- a/lib/tasks/helpers/github.rb
+++ b/lib/tasks/helpers/github.rb
@@ -2,11 +2,15 @@ module Intrigue
   module Task
     module Github
 
-      def initialize_gh_client
-        # the platform may try to pull the deprecated gitrob_access_token for legacy tasks
-        # if that token doesn't exist, try pulling from the github_access_token
-        access_token = _gh_access_token_exists?('github_access_token')
-        access_token ||= _gh_access_token_exists?('gitrob_access_token')
+      def initialize_gh_client(entity_type = nil)
+        if entity_type == 'GithubCredential'
+          access_token = _get_entity_sensitive_detail('github_access_token')
+        else
+          # the platform may try to pull the deprecated gitrob_access_token for legacy tasks
+          # if that token doesn't exist, try pulling from the github_access_token
+          access_token = _gh_access_token_exists?('github_access_token')
+          access_token ||= _gh_access_token_exists?('gitrob_access_token')
+        end
 
         _log_error 'Github Access Token is not set in task config.' if access_token.nil?
         return if access_token.nil?


### PR DESCRIPTION
Hi team,

This PR introduces `GithubCredential` entity support. No major changes were made to the task/helpers, just slight ones in order to support the entity.

Here is a snippet of the boostrap config which can be used to test:
```
"seeds": [{
	"entity": "GithubCredential#MyCreds1",
	"sensitive_details": {
		"github_access_token": "EXAMPLE"
	}
},
{
	"entity": "GithubCredential#InvalidToken",
	"sensitive_details": {
		"github_access_token": "INVALIDEXAMPLE"
	}
}]
```

Thank you.

Best regards,
Maxim