### PR TITLE
AWS Gather EC2 Instances - Cycle Through Regions

### DIFF
--- a/lib/intrigue-tasks.rb
+++ b/lib/intrigue-tasks.rb
@@ -4,6 +4,7 @@
 ### In the case where we're a gem, they're not yet available. add them as deps
 ###
 begin  # try to load runtime deps
+  require 'aws-sdk-core'
   require 'aws-sdk-iam'
   require 'aws-sdk-ecs'
   require 'aws-sdk-ec2'

--- a/lib/tasks/aws_ec2_gather_instances.rb
+++ b/lib/tasks/aws_ec2_gather_instances.rb
@@ -48,7 +48,7 @@ module Intrigue
           instances = ec2.instances
           instances.first # force to authenticate to ensure creds are valid
         rescue Aws::EC2::Errors::UnauthorizedOperation
-          _log_error 'API Key lacks permission to list instances.'
+          _log_error "API Key lacks permission to list instances in #{region}"
           return nil
         rescue Seahorse::Client::NetworkingError
           _log_error "Unable to connect to the AWS EC2 API, this is most likely because #{region} is an invalid region."

--- a/lib/tasks/aws_ec2_gather_instances.rb
+++ b/lib/tasks/aws_ec2_gather_instances.rb
@@ -13,7 +13,7 @@ module Intrigue
           allowed_types: ['String', 'AwsCredential'],
           example_entities: [{ 'type' => 'String', 'details' => { 'name' => '__IGNORE__', 'default' => '__IGNORE__' } }],
           allowed_options: [
-            { name: 'region', regex: 'alpha_numeric', default: 'us-east-1' }
+            { name: 'region', regex: 'alpha_numeric', default: 'changeme-region' }
           ],
           created_types: ['IpAddress']
         }
@@ -27,37 +27,53 @@ module Intrigue
         aws_keys = get_aws_keys_from_entity_type(_get_entity_type_string)
         return unless aws_keys.access_key && aws_keys.secret_key
 
-        aws_region = _get_option 'region'
+        return unless aws_keys_valid?(aws_keys.access_key, aws_keys.secret_key, aws_keys.session_token)
 
-        ec2 = Aws::EC2::Resource.new(region: aws_region, access_key_id: aws_keys.access_key,
-                                     secret_access_key: aws_keys.secret_key, session_token: aws_keys.session_token)
+        regions = retrieve_region_list
+        instance_collection = regions.map do |r|
+          retrieve_instances(r, aws_keys.access_key, aws_keys.secret_key, aws_keys.session_token)
+        end
+
+        instance_collection.compact!
+        return if instance_collection.size.zero?
+
+        create_ec2_instances(instance_collection)
+      end
+
+      def retrieve_instances(region, access_key, secret_key, session_token)
+        ec2 = Aws::EC2::Resource.new(region: region, access_key_id: access_key,
+                                     secret_access_key: secret_key, session_token: session_token)
 
         begin
           instances = ec2.instances
           instances.first # force to authenticate to ensure creds are valid
-        rescue Aws::EC2::Errors::AuthFailure
-          _log_error 'Invalid AWS Keys.'
-          return nil
         rescue Aws::EC2::Errors::UnauthorizedOperation
           _log_error 'API Key lacks permission to list instances.'
           return nil
         rescue Seahorse::Client::NetworkingError
-          _log_error "Unable to connect to the AWS EC2 API, this is most likely because #{aws_region} is an invalid region."
+          _log_error "Unable to connect to the AWS EC2 API, this is most likely because #{region} is an invalid region."
           return nil
         end
 
-        unless instances.count.positive?
-          _log_error "No EC2 instances were discovered in #{aws_region}!"
-          return nil
-        end
+        sleep(1) # dont upset aws
+        _log "Found #{instances.count} instances in #{region}!"
+        instances
+      end
 
-        create_entities instances
+      def retrieve_region_list
+        regions = _get_option('region')
+        return regions.split(',') if regions != 'changeme-region'
+
+        keys = get_aws_keys_from_entity_type(_get_entity_type_string)
+        retrieve_ec2_regions(keys.access_key, keys.secret_key, keys.session_token)
       end
 
       # need to test with ipv6
-      def create_entities(ec2_instances)
-        ec2_instances.each do |instance|
+      def create_ec2_instances(ec2_instance_collection)
+        ec2_instance_collection.reject! { |e| e.count.zero? } # filter out empty collections
 
+        ec2_instance_collection.each do |collection|
+          collection.each do |instance|
           _create_entity 'AwsEC2Instance', {
             'name' => instance.public_dns_name.empty? ? instance.private_dns_name : instance.public_dns_name,
             'region' => instance.placement.availability_zone.chop,
@@ -67,6 +83,7 @@ module Intrigue
             'private_ip_address' => instance.private_ip_address,
             'public_dns_name' => instance.public_dns_name
           }
+          end
         end
       end
 


### PR DESCRIPTION
Hi team,

Please find attached in this PR the implementation to extend the `aws_ec2_gather_instances.rb` task so it will now cycle through all the available AWS regions to the user in scenarios where the default option is passed to the task.

In order to make this task possible, the following was done:
- `aws_keys_valid?()` helper was introduced. Originally the task only supported enumerating one region per run meaning that the credentials were checked and then instances belonging to only one region were gathered. However now that there could be multiple regions, this helper method will be ran when the task starts and if it fails, the task will be aborted. This has the added benefit of not iterating through all the regions when the credentials are invalid. 

- `retrieve_ec2_regions()` helper was added. This will make a call to the return the list of EC2 Regions that the credentials have access to. Rather than hard-coding the list of regions, this can prove helpful in cases where the AWS Key belongs to a government entity in which regions such as `us-gov-east-1` will be accessible. Another added benefit is that this allows the list of regions to be pulled dynamically, without us having to intervene in case a region gets added/removed in AWS. However if the key lacks permission to call the `describe_regions` operation, it will return a hardcoded list of the default regions.

- The `region` task option can also take in an array of regions to cycle through that are delimited by using a comma; e.g:
    - `us-east-1, us-east-2`

Thank you.

Best regards,
Maxim