### PR TITLE
Scoping enhancements

### DIFF
--- a/app/models/global_entity.rb
+++ b/app/models/global_entity.rb
@@ -38,7 +38,8 @@ module Model
         "NetBlock",
         "Uri",
         "UniqueKeyword",
-        "UniqueToken"
+        "UniqueToken",
+        "IpAddress"
       ]
     end
 

--- a/config/config.json.default
+++ b/config/config.json.default
@@ -19,6 +19,7 @@
   "browser_enabled": true,
   "intrigue_task_log_location": "database",
   "intrigue_task_log_level": "error",
+  "scan_internal_ips": false,
   "intrigue_load_paths": [],
   "intrigue_handler_processing_wait_time": 60,
   "intrigue_notifiers": {

--- a/config/config.json.default
+++ b/config/config.json.default
@@ -19,7 +19,6 @@
   "browser_enabled": true,
   "intrigue_task_log_location": "database",
   "intrigue_task_log_level": "error",
-  "scan_internal_ips": false,
   "intrigue_load_paths": [],
   "intrigue_handler_processing_wait_time": 60,
   "intrigue_notifiers": {

--- a/lib/entities/ip_address.rb
+++ b/lib/entities/ip_address.rb
@@ -12,38 +12,7 @@ class IpAddress < Intrigue::Core::Model::Entity
   end
 
   def validate_entity
-    scan_internal = (Intrigue::Core::System::Config.config["scan_internal_ips"] == true ) ? true : false
-    
-    # check if valid ipv4 or ipv6
-    unless name.match(ipv4_regex) || name.match(ipv6_regex)
-      return false
-    end
-    
-    # check if localhost
-    if name.match(/^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$/)
-      return false
-    end
-    
-    # check if we should scan internal
-    # https://docs.microfocus.com/NNMi/10.30/Content/Administer/NNMi_Deployment/Advanced_Configurations/Private_IP_Address_Range.htm
-    unless scan_internal
-      # check if we match 172.16.x.x
-      return false if name.match(/(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)/)
-
-      # check if we match 10.x.x.x
-      return false if name.match(/(^10\.)/)
-
-      # check if we match 192.168.x.x
-      return false if name.match(/(^192\.168\.)/)
-
-      # fc00::/7 address block = RFC 4193 Unique Local Addresses (ULA)
-      return false if name.match(/(^fc00\:)/)
-
-      # fec0::/10 address block = deprecated (RFC 3879)
-      return false if name.match(/(^fec0\:)/)
-    end
-
-    return true
+    return name.match(ipv4_regex) || name.match(ipv6_regex)
   end
 
   def detail_string

--- a/lib/entities/ip_address.rb
+++ b/lib/entities/ip_address.rb
@@ -12,8 +12,38 @@ class IpAddress < Intrigue::Core::Model::Entity
   end
 
   def validate_entity
-    return name.match(ipv4_regex) || name.match(ipv6_regex) &&
-      !name.match(/^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$/)
+    scan_internal = (Intrigue::Core::System::Config.config["scan_internal_ips"] == true ) ? true : false
+    
+    # check if valid ipv4 or ipv6
+    unless name.match(ipv4_regex) || name.match(ipv6_regex)
+      return false
+    end
+    
+    # check if localhost
+    if name.match(/^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$/)
+      return false
+    end
+    
+    # check if we should scan internal
+    # https://docs.microfocus.com/NNMi/10.30/Content/Administer/NNMi_Deployment/Advanced_Configurations/Private_IP_Address_Range.htm
+    unless scan_internal
+      # check if we match 172.16.x.x
+      return false if name.match(/(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)/)
+
+      # check if we match 10.x.x.x
+      return false if name.match(/(^10\.)/)
+
+      # check if we match 192.168.x.x
+      return false if name.match(/(^192\.168\.)/)
+
+      # fc00::/7 address block = RFC 4193 Unique Local Addresses (ULA)
+      return false if name.match(/(^fc00\:)/)
+
+      # fec0::/10 address block = deprecated (RFC 3879)
+      return false if name.match(/(^fec0\:)/)
+    end
+
+    return true
   end
 
   def detail_string

--- a/lib/entity_manager.rb
+++ b/lib/entity_manager.rb
@@ -109,8 +109,22 @@ class EntityManager
     new_entity = Intrigue::Core::Model::Entity.find(:id => entity.id)
 
     # Ensure we have an entity
-    unless new_entity && new_entity.transform! && new_entity.validate_entity
+    unless new_entity
       puts "Error creating entity: #{new_entity}. " + "Entity: #{type_string}##{name} #{details_hash}"
+      return nil
+    end
+
+    ### Run transformation (to hide attributes... HACK)
+    unless new_entity.transform!
+      puts "Transformation of entity failed: #{new_entity}, rolling back entity creation!!"
+      new_entity.delete
+      return nil
+    end
+
+    ### Run Validation
+    unless new_entity.validate_entity
+      puts "Validation of entity failed: #{new_entity}, rolling back entity creation!!"
+      new_entity.delete
       return nil
     end
 

--- a/lib/system/match_exceptions.rb
+++ b/lib/system/match_exceptions.rb
@@ -19,7 +19,12 @@ module System
 
       ip_exceptions = [
         /^127\..*$/,
-        /^0.0.0.0$/
+        /^0.0.0.0$/,
+        /(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)/, # check if we match 172.16.x.x
+        /(^10\.)/, # check if we match 10.x.x.x
+        /(^192\.168\.)/, # check if we match 192.168.x.x
+        /(^fc00\:)/, # fc00::/7 address block = RFC 4193 Unique Local Addresses (ULA)
+        /(^fec0\:)/ # fec0::/10 address block = deprecated (RFC 3879)
       ]
     end
 

--- a/lib/tasks/aws_route53_gather_records.rb
+++ b/lib/tasks/aws_route53_gather_records.rb
@@ -91,14 +91,14 @@ module Intrigue
               # only save the values
               nameservers = item.resource_records.map(&:value)
               _log_good "Retrieved #{nameservers.size} NS records associated with #{item.name}"
-              nameservers.compact.uniq.each { |n| _create_entity 'Nameserver', 'name' => n.scan(subdomain_regex).last.first }
+              nameservers.compact.uniq.each { |n| _create_entity 'Nameserver', {'name' => n.scan(subdomain_regex).last.first, "scoped": true} }
             when 'MX'
               # only save the values -> may save the record name as well however most of the time its set for the domain rather than a specific subdomain
               mxvalues = item.resource_records.map(&:value)
-              mxvalues.compact.uniq.each { |m| _create_entity 'Mailserver', 'name' => m.scan(subdomain_regex).last.first }
+              mxvalues.compact.uniq.each { |m| _create_entity 'Mailserver', {'name' => m.scan(subdomain_regex).last.first, "scoped": true} }
             when 'A', 'CNAME', 'AAAA', 'SRV'
               _log_good "Retrieved the following #{item.type} Record: #{item.name.scan(subdomain_regex).last.first}"
-              _create_entity 'DnsRecord', 'name' => item.name.scan(subdomain_regex).last.first
+              _create_entity 'DnsRecord', { 'name' => item.name.scan(subdomain_regex).last.first, "scoped": true}
             end
           end
         end

--- a/lib/tasks/aws_route53_gather_records.rb
+++ b/lib/tasks/aws_route53_gather_records.rb
@@ -91,7 +91,7 @@ module Intrigue
               # only save the values
               nameservers = item.resource_records.map(&:value)
               _log_good "Retrieved #{nameservers.size} NS records associated with #{item.name}"
-              nameservers.compact.uniq.each { |n| _create_entity 'Nameserver', {'name' => n.scan(subdomain_regex).last.first, "scoped": true} }
+              nameservers.compact.uniq.each { |n| _create_entity 'Nameserver', {'name' => n.scan(subdomain_regex).last.first} }
             when 'MX'
               # only save the values -> may save the record name as well however most of the time its set for the domain rather than a specific subdomain
               mxvalues = item.resource_records.map(&:value)


### PR DESCRIPTION
Scopes in dns and mail records automatically in if they're coming from AwsCredential. Also enables a configuration option for disabling creation of internal ip addresses (by default, its enabled). 