### PR TITLE
Support GithubAccount entity names in two formats

### DIFF
--- a/lib/entities/github_account.rb
+++ b/lib/entities/github_account.rb
@@ -12,6 +12,7 @@ module Intrigue
 
       def self.transform_before_save(name, details_hash)
         new_name = "https://github.com/#{name}" unless name.match(/^https:\/\/github.com\/[\w\-]{1,39}$/)
+        details_hash[:name] = new_name
         return new_name, details_hash
       end
 

--- a/lib/entities/github_account.rb
+++ b/lib/entities/github_account.rb
@@ -11,6 +11,7 @@ module Intrigue
       end
 
       def self.transform_before_save(name, details_hash)
+        new_name = name
         new_name = "https://github.com/#{name}" unless name.match(/^https:\/\/github.com\/[\w\-]{1,39}$/)
         details_hash[:name] = new_name
         return new_name, details_hash

--- a/lib/entities/github_account.rb
+++ b/lib/entities/github_account.rb
@@ -10,13 +10,18 @@ module Intrigue
         }
       end
 
+      def self.transform_before_save(name, details_hash)
+        new_name = "https://github.com/#{name}" unless name.match(/^https:\/\/github.com\/[\w\-]{1,39}$/)
+        return new_name, details_hash
+      end
+
       def validate_entity
         name.match /^https:\/\/github.com\/[\w\-]{1,39}$/
       end
 
       def enrichment_tasks
         # to enrich github accounts, use enrich/github_account and prepend to array below
-        ['gather_github_repositories']
+        ['enrich/github_account']
       end
 
       def scoped?

--- a/lib/tasks/enrich/github_account.rb
+++ b/lib/tasks/enrich/github_account.rb
@@ -26,7 +26,13 @@ module Intrigue
         ## Default method, subclasses must override this
         
         def run
-          _log "Marking #{_get_entity_type_string}: #{_get_entity_name} enriched!"
+          # check if account exists
+          account_name = _get_entity_name
+          unless check_uri_exists(account_name, :code)
+            # this account does not exist.
+            @entity.hidden = true
+            @entity.save
+          end
         end
       end
     end

--- a/lib/tasks/gather_github_repositories.rb
+++ b/lib/tasks/gather_github_repositories.rb
@@ -5,7 +5,7 @@ module Intrigue
 
       def self.metadata
         {
-          name: 'Gather Github Repositories',
+          name: 'gather_github_repositories',
           pretty_name: 'Gather Github Repositories',
           authors: ['jcran', 'maxim'],
           description: 'Gathers repositories belonging to a Github account (personal/organization). This task uses either authenticated or unauthenticated techniques based on whether a Github Access Token is provided. Please note that the unauthenticated technique is rate limited at 60 requests per hour, while the authenticated technique allows for 5,000 requests per hour. <br><br>Allowed Task Entities:<br><ul><li><b>String</b> - (default value: __IGNORE__) - <b>Requires Valid Github Access Token</b>. Leave this default if you would like to retrieve all repositories belonging to the access token.</li><li><b>Github Account</b> - (Default value: intrigueio) - If you would like to retrieve repositories for a specific Github account, use this entity. This will use either authenticated or unauthenticated techniques to retrieve repositories belonging to the account specified.</li></ul>',

--- a/lib/tasks/gather_github_repositories.rb
+++ b/lib/tasks/gather_github_repositories.rb
@@ -75,7 +75,7 @@ module Intrigue
           _log_error 'Authentication is required when using a String/GithubCredential entity.'
           good = false
         when '422'
-          _log_error 'Github Account does not exist; aborting.'
+          _log_error 'Github Account does not exist or no permission to access; aborting.'
           good = false
         end
         good


### PR DESCRIPTION
We recently decided that GithubAccount entities must be in the format: `https://github.com/account_name_here`. However, in platform we already have seeds that are GithubAccount entities in a format without the `https://github.com` prefix. 

To solve this problem, I've used the entity `transform_before_save` functionality to prepend `https://github.com` if its not present. Additionally, this PR uses the GithubAccount enrichment functionality to check whether the account exists, and hides the entity if it does not exist.